### PR TITLE
Upgrade linting mypy -> basedpyright.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ right" but *absolutely as simple as possible*:
   machinery needed to update/commit files every release).
 
 - Standard, modern linting, formatting, and testing with
-  [**ruff**](https://github.com/charliermarsh/ruff),
-  [**mypy**](https://github.com/python/mypy),
+  [**ruff**](https://github.com/charliermarsh/ruff) (a linter and formatter that now
+  replaces [black](https://github.com/psf/black)),
+  [**BasedPyright**](https://github.com/detachhead/basedpyright) (an improved
+  alternative to [pyright](https://github.com/microsoft/pyright) that is faster than
+  [mypy](https://github.com/python/mypy) and seems to have better
+  [VSCode/Cursor support](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright)),
   [**codespell**](https://github.com/codespell-project/codespell), and
   [**pytest**](https://github.com/pytest-dev/pytest).
 

--- a/template/devtools/lint.py
+++ b/template/devtools/lint.py
@@ -1,6 +1,7 @@
 import subprocess
 
 from rich import print as rprint
+from funlog import log_calls
 
 # Update as needed.
 SRC_PATHS = ["src", "tests", "devtools"]
@@ -11,10 +12,10 @@ def main():
     rprint()
 
     errcount = 0
-    errcount += _run(["codespell", "--write-changes", *SRC_PATHS, *DOC_PATHS])
-    errcount += _run(["ruff", "check", "--fix", *SRC_PATHS])
-    errcount += _run(["ruff", "format", *SRC_PATHS])
-    errcount += _run(["mypy", *SRC_PATHS])
+    errcount += run(["codespell", "--write-changes", *SRC_PATHS, *DOC_PATHS])
+    errcount += run(["ruff", "check", "--fix", *SRC_PATHS])
+    errcount += run(["ruff", "format", *SRC_PATHS])
+    errcount += run(["basedpyright", *SRC_PATHS])
 
     rprint()
 
@@ -27,7 +28,9 @@ def main():
     return errcount
 
 
-def _run(cmd: list[str]) -> int:
+@log_calls(level="warning", show_timing_only=True)
+def run(cmd: list[str]) -> int:
+    rprint()
     rprint(f"[bold green]❯ {' '.join(cmd)}[/bold green]")
     errcount = 0
     try:
@@ -35,7 +38,6 @@ def _run(cmd: list[str]) -> int:
     except subprocess.CalledProcessError as e:
         rprint(f"[bold red]Error: {e}[/bold red]")
         errcount = 1
-    rprint()
 
     return errcount
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -21,9 +21,10 @@ dependencies = []
 dev = [
     "pytest>=8.3.5",
     "ruff>=0.11.0",
-    "mypy>=1.15.0",
     "codespell>=2.4.1",
     "rich>=13.9.4",
+    "basedpyright>=1.28.2",
+    "funlog>=0.2.0",
 ]
 
 [project.scripts]
@@ -95,11 +96,22 @@ ignore = [
     "ISC002", # https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/
 ]
 
-
-[tool.mypy]
-disable_error_code = [
-    "import-untyped",
-]
+# BasedPyright now seems like the best type checker option, much faster than
+# mypy and has a good extension for VSCode/Cursor.
+# https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright
+# https://docs.basedpyright.com/latest/configuration/config-files/#sample-pyprojecttoml-file
+[tool.basedpyright]
+include = ["src", "tests", "devtools"]
+# Typically noisy, uncomment as needed:
+# reportMissingImports = false
+# reportUnusedCallResult = false
+# reportUnnecessaryIsInstance = false
+# reportUnreachable = false
+# reportAny = false
+# reportExplicitAny = false
+# reportUnknownVariableType = false
+# reportUnknownArgumentType = false
+# reportMissingTypeStubs = false
 
 [tool.codespell]
 # ignore-words-list = "foo,bar"


### PR DESCRIPTION
had to set up my Cursor configs again and seemed like BasedPyright now has better support for CLI and VSCode and its forks.