### PR TITLE
Ignore and clean .ruff_cache/ in template

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -6,6 +6,11 @@ trash/
 attic/
 .kash/
 
+# Python tool caches
+.ruff_cache/
+
+# GitHub's standard Python .gitignore:
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/template/Makefile
+++ b/template/Makefile
@@ -31,6 +31,7 @@ clean:
 	-rm -rf dist/
 	-rm -rf *.egg-info/
 	-rm -rf .pytest_cache/
+	-rm -rf .ruff_cache/
 	-rm -rf .mypy_cache/
 	-rm -rf .venv/
 	-find . -type d -name "__pycache__" -exec rm -rf {} +


### PR DESCRIPTION
## Summary

Addresses #14 ("Add more gitignore entries" — `.ruff_cache` is missing).

The reporter is right, and the gap is specifically in the **template** (what generated projects receive), not the repo root:

- The repo's own root `.gitignore` already ignored `.ruff_cache/`, but `template/.gitignore` did not. Since `ruff` is a core lint+format tool in this template, generated projects would see `.ruff_cache/` as untracked. Fixed by adding it under a new labeled `# Python tool caches` section, mirroring the root repo's structure.
- While reviewing, I found a related inconsistency: the template `Makefile` `clean` target removed the **unused** `.mypy_cache/` but not the `.ruff_cache/` that the template actually produces. Added `.ruff_cache/` to `clean`.

## Scope decision

I kept this deliberately minimal to match the template's stated "minimalist, modern, maintained" philosophy (based on GitHub's standard Python `.gitignore` plus a small additions section). I intentionally did **not** add OS/editor entries like `.DS_Store`, since the README explicitly keeps editor/OS config out of the template. Happy to broaden if you'd prefer.

## Tracking

Mapped under a single beads epic (`smu-vmt6`) with two tasks (`smu-agil`, `smu-mvf2`), now closed.

Closes #14

https://claude.ai/code/session_01CB2Unh2uNEQuYUS8ZU9b9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01CB2Unh2uNEQuYUS8ZU9b9N)_