### PR TITLE
Validate and auto-derive package_module in copier prompts

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -27,8 +27,17 @@ package_name:
 
 package_module:
     type: str
-    help: Package module name? (This is the Python module, so use snake_case. Or press enter to fill in later.)
-    default: changeme
+    help: Package module name? (This is the Python module, so use snake_case. Or press enter to derive it from the package name.)
+    # Derive a valid module name from the package name so dash-case or CamelCase
+    # names (fine for GitHub/PyPI) don't silently produce a broken Python module.
+    default: "{{ package_name|lower|replace('-', '_') }}"
+    # A Python module name must be a valid identifier and is conventionally
+    # lowercase snake_case; dashes/spaces/leading digits produce code that won't
+    # import (e.g. `from .polars-row-collector import *`).
+    validator: >-
+        {% if not package_module.isidentifier() or package_module != package_module.lower() %}
+        package_module must be a lowercase, snake_case Python module name (no dashes, spaces, or leading digits). For example, use "polars_row_collector" instead of "polars-row-collector".
+        {% endif %}
 
 package_description:
     type: str


### PR DESCRIPTION
## Summary

Fixes #13 — entering dashes (or other non-identifier characters) in the `package_module` prompt silently produced broken output, e.g.:

```python
from .polars-row-collector import *  # invalid Python
```

plus an invalid `pyproject.toml`, with no warning. The root cause: `copier.yml` didn't validate `package_module` (which must be a valid Python identifier) and its default didn't derive from `package_name`, so users who conflate the GitHub/PyPI name (dash-case is fine) with the Python module name (must be snake_case) got broken code.

## Changes (`copier.yml`)

1. **Default `package_module` from `package_name`**, lowercased with dashes → underscores (`{{ package_name|lower|replace('-', '_') }}`). Pressing enter after a dash-case name now yields a valid snake_case module instead of a broken one. The no-input `changeme` default is unchanged.
2. **Validator** rejecting any module name that isn't a lowercase Python identifier (dashes, spaces, leading digits, uppercase), with an example-based error message.

## Verification

Tested locally with copier 9.15.1 against the working-tree template:

- **Rejection path** — `package_module="polars-row-collector"` → fails with the clear validation error.
- **Derivation path** — `package_name="polars-row-collector"`, module left to default → generates `src/polars_row_collector/`, `from .polars_row_collector import *`, `polars-row-collector = "polars_row_collector:main"` in `pyproject.toml`, and **all generated `.py` files parse**.

## Tracking

Beads epic `smu-p96f` (tasks `smu-vvir`, `smu-g4l3`), now closed.

Closes #13

https://claude.ai/code/session_01CB2Unh2uNEQuYUS8ZU9b9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01CB2Unh2uNEQuYUS8ZU9b9N)_