### PR TITLE
feat: prepare focused v0.4.0 template refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Supply-chain cool-off for template dependency resolution, matching the
-      # template's own CI (see updating.md). Scoped to the render/update jobs:
-      # the format-check job runs only the Makefile's explicitly pinned formatter,
-      # which may legitimately be newer than the cool-off window.
+      # template's own CI and the Makefile default (see updating.md).
       UV_EXCLUDE_NEWER: "14 days"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -191,6 +189,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Validate skill structure and frontmatter
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          NPM_CONFIG_BEFORE: "2026-06-29T03:27:33Z"
         run: npx --yes skills-ref@0.1.5 validate skills/simple-modern-uv
       - name: Check that relative links in skill docs resolve
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           git init -q --initial-branch=main
           git add -A
           git -c user.email=ci@example.com -c user.name=CI commit -qm "Initial commit"
-          uv sync --all-extras
+          uv sync --all-extras --all-groups
           V=$(uv run python -c "from importlib.metadata import version; print(version('smoke-test'))")
           echo "installed version: $V"
           test "$V" != "0.0.0"
@@ -119,7 +119,7 @@ jobs:
           uv run python devtools/lint.py --check
           uv run pytest
           git tag v0.1.0
-          uv build
+          uv build --no-build-isolation
           ls dist/ | grep -q "smoke_test-0.1.0-py3-none-any.whl"
 
   update-path:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ permissions:
 env:
   # Pinned tool versions used to exercise the template. Keep the uv version in
   # sync with template/.github/workflows/ci.yml when updating.
-  UV_VERSION: "0.11.17"
-  COPIER_SPEC: "copier@9.15.1"
+  UV_VERSION: "0.11.25"
+  COPIER_SPEC: "copier@9.16.0"
   # Default answers for test renders.
   RENDER_ARGS: >-
     --data package_name=smoke-test
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.17"
+          version: "0.11.25"
       - name: Check doc formatting
         run: make format-check
 
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.17"
+          version: "0.11.25"
           enable-cache: true
           python-version: "3.12"
 
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.17"
+          version: "0.11.25"
 
       - name: Render from previous release tag
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   # Pinned tool versions used to exercise the template. Keep the uv version in
   # sync with template/.github/workflows/ci.yml when updating.
   UV_VERSION: "0.11.25"
+  UV_CHECKSUM: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
   COPIER_SPEC: "copier@9.16.0"
   # Default answers for test renders.
   RENDER_ARGS: >-
@@ -31,10 +32,13 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          version: "0.11.25"
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          checksum: ${{ env.UV_CHECKSUM }}
       - name: Check doc formatting
         run: make format-check
 
@@ -56,12 +60,14 @@ jobs:
       # which may legitimately be newer than the cool-off window.
       UV_EXCLUDE_NEWER: "14 days"
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.1.0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.25"
+          version: ${{ env.UV_VERSION }}
+          checksum: ${{ env.UV_CHECKSUM }}
           enable-cache: true
           python-version: "3.12"
 
@@ -131,12 +137,14 @@ jobs:
     env:
       UV_EXCLUDE_NEWER: "14 days"
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v8.1.0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.25"
+          version: ${{ env.UV_VERSION }}
+          checksum: ${{ env.UV_CHECKSUM }}
 
       - name: Render from previous release tag
         run: |
@@ -179,7 +187,9 @@ jobs:
   skill-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Validate skill structure and frontmatter
         run: npx --yes skills-ref@0.1.5 validate skills/simple-modern-uv
       - name: Check that relative links in skill docs resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ make format
 make format-check
 
 # Render the template non-interactively (smoke test):
-uvx copier@9.15.1 copy --defaults --vcs-ref=HEAD --data package_name=smoke-test \
+uvx copier@9.16.0 copy --defaults --vcs-ref=HEAD --data package_name=smoke-test \
   --data package_github_org=testorg . /tmp/smoke-test
 # Then inside the render: uv sync --all-extras && uv run python devtools/lint.py --check && uv run pytest
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ make format
 make format-check
 
 # Render the template non-interactively (smoke test):
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults --vcs-ref=HEAD \
+uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults --vcs-ref=HEAD \
   --data package_name=smoke-test \
   --data package_github_org=testorg . /tmp/smoke-test
 # Then inside the render: make install && make lint-check && make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ make format
 make format-check
 
 # Render the template non-interactively (smoke test):
-uvx copier@9.16.0 copy --defaults --vcs-ref=HEAD --data package_name=smoke-test \
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults --vcs-ref=HEAD \
+  --data package_name=smoke-test \
   --data package_github_org=testorg . /tmp/smoke-test
-# Then inside the render: uv sync --all-extras && uv run python devtools/lint.py --check && uv run pytest
+# Then inside the render: make install && make lint-check && make test
 ```
 
 ## Architecture Overview

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@
 
 .DEFAULT_GOAL := format
 
+# Safe default for every uv/uvx resolution invoked through this Makefile.
+UV_EXCLUDE_NEWER ?= 14 days
+export UV_EXCLUDE_NEWER
+
 # Pinned for reproducibility and supply-chain hygiene (see updating.md).
 FLOWMARK := uvx flowmark-rs@0.3.1
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ License and publishing are template questions, not hand edits: `package_license`
 decide later) and `publish_to_pypi` (answer no for a private package; the publish
 workflow and docs are then omitted).
 Answer them at render time or change them later with
-`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=…`; see the
+`uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=…`; see the
 skill’s [customize guide](skills/simple-modern-uv/references/customize.md) for details.
 Prefer re-answering over hand-deleting generated files like `publish.yml`, so future
 `copier update` runs stay consistent.
@@ -330,7 +330,7 @@ cd ~/projects/github   # Wherever you do your project work.
 # Clone this template under the supply-chain cool-off. This does everything!
 # It will fetch from this GitHub repo and create a new directory
 # with whatever name you put below:
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy \
+uvx --exclude-newer "14 days" copier@9.16.0 copy \
   gh:jlevy/simple-modern-uv YOURNEWREPO
 # Then follow the instructions.
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Install the [skill](skills/simple-modern-uv/SKILL.md) (the
 Codex, Cursor, Gemini CLI, and 50+ other agents):
 
 ```shell
-npx skills add jlevy/simple-modern-uv
+NPM_CONFIG_IGNORE_SCRIPTS=true NPM_CONFIG_BEFORE=2026-06-29T03:27:33Z \
+  npx --yes skills@1.5.13 add jlevy/simple-modern-uv
 ```
 
 Then tell your agent what you want, for example:
@@ -292,8 +293,8 @@ License and publishing are template questions, not hand edits: `package_license`
 decide later) and `publish_to_pypi` (answer no for a private package; the publish
 workflow and docs are then omitted).
 Answer them at render time or change them later with
-`copier update --data package_license=…`; see the skill’s
-[customize guide](skills/simple-modern-uv/references/customize.md) for details.
+`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=…`; see the
+skill’s [customize guide](skills/simple-modern-uv/references/customize.md) for details.
 Prefer re-answering over hand-deleting generated files like `publish.yml`, so future
 `copier update` runs stay consistent.
 
@@ -320,19 +321,17 @@ Using Copier is the recommended approach since it then lets you instantiate the 
 variables and makes future updates possible.
 But it requires a few more commands.
 
-To create a new project repo with `copier`:
+To create a new project repo with the reviewed Copier version:
 
 ```shell
-# Install Copier:
-uv tool install copier
-
 # Change dirs to the place you want the new GitHub repo to be.
 cd ~/projects/github   # Wherever you do your project work.
 
-# Clone this template. This does everything!
+# Clone this template under the supply-chain cool-off. This does everything!
 # It will fetch from this GitHub repo and create a new directory
 # with whatever name you put below:
-copier copy gh:jlevy/simple-modern-uv YOURNEWREPO
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy \
+  gh:jlevy/simple-modern-uv YOURNEWREPO
 # Then follow the instructions.
 ```
 
@@ -353,7 +352,7 @@ git commit -m "Initial commit from simple-modern-uv."
 # Sync after the first commit so dynamic versioning gives the editable install
 # a real version (not 0.0.0). This creates uv.lock; commit it so CI installs
 # reproducibly with --frozen.
-uv sync --all-extras
+make install
 git add uv.lock
 git commit -m "Add uv.lock."
 # Create repo on GitHub.

--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ follows:
 - **Cooling-off period:** Don’t install or upgrade to a release less than 14 days old
   (most malicious publishes are caught within days).
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this template’s CI and Makefile set it automatically.
+  duration like `"14 days"`); this template sets it in generated `pyproject.toml`, CI,
+  and the Makefile.
 
 - **Vet what you add:** Only add dependencies you can verify upstream, and prefer a
   little first-party code over pulling in a new dependency.

--- a/README.md
+++ b/README.md
@@ -430,13 +430,14 @@ follows:
 - **Cooling-off period:** Don’t install or upgrade to a release less than 14 days old
   (most malicious publishes are caught within days).
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this template’s CI sets it automatically.
+  duration like `"14 days"`); this template’s CI and Makefile set it automatically.
 
 - **Vet what you add:** Only add dependencies you can verify upstream, and prefer a
   little first-party code over pulling in a new dependency.
 
-- **Pin and lock:** Commit your `uv.lock` and pin GitHub Actions to a commit SHA (or at
-  least a full, immutable version tag) so a tag can’t be silently re-pointed.
+- **Pin and lock:** Commit your `uv.lock` and pin GitHub Actions to full commit SHAs.
+  Treat a version tag as immutable only after verifying that release state through the
+  GitHub API.
 
 See [updating.md](updating.md#supply-chain-hygiene) for how this template applies these.
 

--- a/copier.yml
+++ b/copier.yml
@@ -11,7 +11,7 @@ _message_after_copy: |
     Remember to look for any unfilled `changeme` strings!
     The license and publishing setup follow your package_license and
     publish_to_pypi answers; change them later with, e.g.:
-    UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=Apache-2.0
+    uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=Apache-2.0
 
     Next steps:
 

--- a/copier.yml
+++ b/copier.yml
@@ -11,7 +11,7 @@ _message_after_copy: |
     Remember to look for any unfilled `changeme` strings!
     The license and publishing setup follow your package_license and
     publish_to_pypi answers; change them later with, e.g.:
-    copier update --data package_license=Apache-2.0
+    UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=Apache-2.0
 
     Next steps:
 
@@ -22,7 +22,7 @@ _message_after_copy: |
     # Sync after the first commit so dynamic versioning gives the editable
     # install a real version (not 0.0.0). This creates uv.lock; commit it so
     # CI installs reproducibly with --frozen.
-    uv sync --all-extras
+    make install
     git add uv.lock
     git commit -m "Add uv.lock."
     # Create an empty repo on GitHub, then:

--- a/docs/project/research/research-uv-changes.md
+++ b/docs/project/research/research-uv-changes.md
@@ -63,7 +63,9 @@ doc.)
    The build backends are exact-pinned and mirrored in a locked `build` dependency
    group; release builds use `--no-build-isolation` so `uv.lock` covers the build graph.
 2. **`[tool.uv] required-version = ">=0.9"`** (adopted): fails fast on uv versions that
-   predate relative-duration `UV_EXCLUDE_NEWER`.
+   predate relative-duration `UV_EXCLUDE_NEWER`. The same `[tool.uv]` table sets
+   `exclude-newer = "14 days"` so direct uv commands, not only Makefile and CI paths,
+   inherit the policy.
 3. **Watch `uv audit` and `UV_MALWARE_CHECK`**: `uv audit` is old enough to use as an
    additional release-time check, but remains preview functionality in 0.11.25. Do not
    make a preview command part of generated-project CI until it stabilizes.

--- a/docs/project/research/research-uv-changes.md
+++ b/docs/project/research/research-uv-changes.md
@@ -1,6 +1,6 @@
 # Research: uv Changes Relevant to This Template
 
-**Last updated:** 2026-06-11
+**Last updated:** 2026-07-12
 
 **Author:** Joshua Levy (with agent assistance)
 
@@ -12,8 +12,10 @@ This template was created in March 2025, when uv was on 0.6.x. This living doc t
 uv’s evolution since then, focused on what matters to the template: defaults, build
 backends, publishing, supply-chain features, and anything that would change the
 template’s recommendations.
-As of 2026-06-11 the latest uv is **0.11.20** (the template pins **0.11.17** in CI, the
-newest version clearing the 14-day supply-chain cool-off).
+At the v0.4.0 dependency freeze (2026-07-13T03:27:33Z), the latest uv was **0.11.28**.
+The template pins **0.11.25**, the newest version clearing the exact 14-day supply-chain
+cutoff. See the [release manifest](research-v0.4.0-supply-chain-manifest.md) for dates
+and provenance.
 
 ## Timeline of Notable Changes
 
@@ -42,7 +44,10 @@ newest version clearing the 14-day supply-chain cool-off).
   2026-06-08): scans `uv.lock` against the OSV database, with
   `--ignore`/`--ignore-until-fixed`. Opt-in **malware checks** on `uv add`/`uv sync` via
   `UV_MALWARE_CHECK=1` (0.11.16+). **`uv check`** (0.11.18, preview): runs Astral’s ty
-  type checker. Python 3.15.0b2 in managed downloads; 3.15 final expected ~Oct 2026.
+  type checker. Python 3.15 betas are available in managed downloads; 3.15 final is
+  expected around October 2026. **0.11.25 hardens tar handling** against parser
+  differentials and rejects malformed or ambiguous source distributions that older uv
+  versions could accept.
 
 (Compiled from uv release notes and the Astral blog; re-verify details against the
 [changelog](https://github.com/astral-sh/uv/blob/main/CHANGELOG.md) when updating this
@@ -55,20 +60,23 @@ doc.)
    minimal: no plugin mechanism, so no dynamic versioning from git tags, which is core
    to this template’s release model.
    Revisit if uv grows native dynamic versioning.
+   The build backends are exact-pinned and mirrored in a locked `build` dependency
+   group; release builds use `--no-build-isolation` so `uv.lock` covers the build graph.
 2. **`[tool.uv] required-version = ">=0.9"`** (adopted): fails fast on uv versions that
    predate relative-duration `UV_EXCLUDE_NEWER`.
-3. **Watch `uv audit` and `UV_MALWARE_CHECK`**: both preview and brand-new (audit
-   announced 2026-06-08, inside the cool-off window).
-   Adopt in the template’s CI once stable; they fit the template’s supply-chain posture
-   well. Until then they are mentioned here, not wired in.
+3. **Watch `uv audit` and `UV_MALWARE_CHECK`**: `uv audit` is old enough to use as an
+   additional release-time check, but remains preview functionality in 0.11.25. Do not
+   make a preview command part of generated-project CI until it stabilizes.
+   Continue watching the opt-in malware check for the same reason.
 4. **Keep `devtools/lint.py` over `uv format`/`uv check`** (decision).
    One command runs codespell, ruff check, ruff format, and basedpyright together, which
    neither uv command covers; `uv check` is also ty-based and preview (see the
    [type-checker research doc](research-python-type-checkers.md)).
 5. **Python 3.15**: add to the CI matrix and classifiers when final (~Oct 2026).
 6. **uv pin currency**: bump the pinned uv in `template/.github/workflows/*` at each
-   update cycle to the newest version clearing the 14-day cool-off (0.11.17 as of this
-   writing).
+   update cycle to the newest version clearing the 14-day cool-off (0.11.25 at the
+   v0.4.0 freeze). Update the setup-uv action and official platform checksum in the same
+   reviewed change.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -1,0 +1,97 @@
+# Research: v0.4.0 Supply-Chain Manifest
+
+**Frozen:** 2026-07-13T03:27:33Z
+
+**Eligibility cutoff:** 2026-06-29T03:27:33Z (14 days)
+
+**Status:** Frozen for the v0.4.0 release
+
+## Scope and Decision Rule
+
+This manifest freezes the dependency and executable-tool candidates for v0.4.0.
+Implementation must not chase releases published after the freeze.
+A version is eligible only when its first non-yanked artifact was published on or before
+the cutoff, its canonical source and release notes are reviewable, and no known advisory
+blocks it.
+
+The audit covers the template inputs, generated-project development and build
+dependencies, repository-only tools, and active GitHub Actions.
+It does not approve transitive packages by implication; the rendered `uv.lock` diff is
+reviewed separately.
+
+## Frozen Python and Tool Candidates
+
+| Component | Current declaration | Frozen decision | Published (UTC) | Source and rationale |
+| --- | --- | --- | --- | --- |
+| uv | 0.11.17 | **Update to [0.11.25](https://github.com/astral-sh/uv/releases/tag/0.11.25)** | 2026-06-27 | Official Astral release; includes tar parser-differential hardening and attested GitHub release assets |
+| Copier | 9.15.1 | **Update to [9.16.0](https://github.com/copier-org/copier/releases/tag/v9.16.0)** | 2026-06-23 | Official Copier release; remote-cache/worktree and gitignored-file update behavior needs copy/update validation |
+| Flowmark | 0.3.1 | Keep 0.3.1 | 2026-05-30 | Canonical `jlevy/flowmark-rs`; already latest |
+| pytest | >=9.0.3 | **Raise to [>=9.1.1](https://github.com/pytest-dev/pytest/releases/tag/9.1.1)** | 2026-06-19 | Official pytest release; PyPI provenance present |
+| pytest-sugar | >=1.1.1 | Keep >=1.1.1 | 2025-08-23 | Already latest |
+| Ruff | >=0.15.15 | **Raise to [>=0.15.20](https://github.com/astral-sh/ruff/releases/tag/0.15.20)** | 2026-06-25 | Official Astral release with attested GitHub release assets |
+| codespell | >=2.4.2 | Keep >=2.4.2 | 2026-03-05 | Already latest |
+| Rich | >=15.0.0 | Keep >=15.0.0 | 2026-04-12 | Already latest |
+| basedpyright | >=1.39.6 | **Raise to [>=1.39.9](https://github.com/DetachHead/basedpyright/releases/tag/v1.39.9)** | 2026-06-27 | Canonical DetachHead release; immutable GitHub release |
+| funlog | >=0.2.1 | Keep >=0.2.1 | 2025-03-28 | Canonical `jlevy/funlog`; already latest |
+| Hatchling | unbounded build requirement | **Add >=1.30.1 floor** | 2026-06-02 | Official PyPA backend; 1.31.0 is too fresh |
+| uv-dynamic-versioning | unbounded build requirement | **Add >=0.14.0 floor** | 2026-03-22 | Canonical ninoseki project; already latest |
+| skills-ref | 0.1.5 | Keep 0.1.5 | 2025-12-27 | Exact npm package and integrity are pinned; already latest |
+| get-tbd | 0.2.3 | Evaluate 0.3.0 separately | 2026-06-15 | Repository-only bootstrap; npm integrity verified before execution |
+
+The Python compatibility matrix remains 3.11 through 3.14. Python 3.15 is pre-release
+and is not added to classifiers or CI.
+
+## Frozen GitHub Actions
+
+| Action | Frozen version | Full commit | Release state | Decision |
+| --- | --- | --- | --- | --- |
+| `actions/checkout` | [v7.0.0](https://github.com/actions/checkout/releases/tag/v7.0.0) | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | Not immutable | Pin the full commit SHA; verify Node 24 runner compatibility and disable persisted credentials |
+| `astral-sh/setup-uv` | [v8.2.0](https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0) | `fac544c07dec837d0ccb6301d7b5580bf5edae39` | Immutable | Pin the full commit SHA and continue pinning the uv version independently |
+
+Full commit pins are used for both actions so workflow review has one consistent rule.
+The generated publish workflow retains only `contents: read` and `id-token: write`; CI
+workflows retain `contents: read`.
+
+## Provenance and Advisory Results
+
+- OSV batch queries returned no advisories for the frozen direct versions of uv, Copier,
+  pytest, Ruff, basedpyright, skills-ref, or get-tbd.
+- PyPI provenance was present for the Copier 9.16.0 and pytest 9.1.1 source
+  distributions. PyPI did not expose provenance for the audited uv, Ruff, or basedpyright
+  source distributions.
+  uv and Ruff publish GitHub artifact attestations; basedpyright provides an immutable
+  GitHub release and PyPI SHA-256 digests.
+- The npm registry integrity values were recorded before any execution:
+  `skills-ref@0.1.5` is
+  `sha512-C2vyZbUQqt3PXA9vcdUmJ0lwbH9jK19C9fwQjl/ICPy2e5bzV3CaropViakJCv+HLt/9zsgjZ/NLJ5xEri0jSA==`;
+  `get-tbd@0.3.0` is
+  `sha512-2N6MB1nSKIJK0Frnw+y4k8tiYNItNF0P7Ne4TaOyz1Mp6NTWTNqRooqYsHxwdyKLhU2FVM/TJek/NGT97joo4w==`.
+- These direct checks do not replace inspection of the generated `uv.lock`, artifact
+  hashes, or an advisory scan of the complete resolved graph.
+
+## Explicit Deferrals
+
+The following releases were younger than the cutoff and are excluded without exception:
+
+- uv 0.11.26 through 0.11.28
+- Ruff 0.15.21
+- setup-uv v8.3.1 and v8.3.2
+- Hatchling 1.31.0
+- get-tbd 0.4.0
+
+`uv audit` remains preview functionality in this uv series.
+It may be used as an additional release-time check, but this release does not make a
+preview command a generated-project CI contract.
+
+## Validation Gates
+
+1. Inspect all direct and transitive changes in a freshly rendered `uv.lock`.
+2. Reject yanked, post-cutoff, unexpected-source, or unexplained packages.
+3. Run advisory checks for the complete lock graph.
+4. Exercise fresh copy and v0.3.0-to-candidate update paths with Copier 9.16.0.
+5. Run lint, type checking, tests, and builds on Python 3.11 through 3.14.
+6. Require template-repository CI and the long-lived downstream release gate to pass.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -35,6 +35,7 @@ reviewed separately.
 | funlog | >=0.2.1 | Keep >=0.2.1 | 2025-03-28 | Canonical `jlevy/funlog`; already latest |
 | Hatchling | unbounded build requirement | **Pin 1.30.1** | 2026-06-02 | Official PyPA backend; 1.31.0 is too fresh |
 | uv-dynamic-versioning | unbounded build requirement | **Pin 0.14.0** | 2026-03-22 | Canonical ninoseki project; already latest |
+| skills installer | unpinned `npx skills` | **Pin skills 1.5.13** | 2026-06-23 | Canonical Vercel Labs CLI; npm provenance, registry signature, and integrity present |
 | skills-ref | 0.1.5 | Keep 0.1.5 | 2025-12-27 | Exact npm package and integrity are pinned; already latest |
 | get-tbd | 0.2.3 | Evaluate 0.3.0 separately | 2026-06-15 | Repository-only bootstrap; npm integrity verified before execution |
 
@@ -65,13 +66,15 @@ run, authoritative for release artifacts.
 ## Provenance and Advisory Results
 
 - OSV batch queries returned no advisories for the frozen direct versions of uv, Copier,
-  pytest, Ruff, basedpyright, skills-ref, or get-tbd.
+  pytest, Ruff, basedpyright, skills, skills-ref, or get-tbd.
 - PyPI provenance was present for the Copier 9.16.0 and pytest 9.1.1 source
   distributions. PyPI did not expose provenance for the audited uv, Ruff, or basedpyright
   source distributions.
   uv and Ruff publish GitHub artifact attestations; basedpyright provides an immutable
   GitHub release and PyPI SHA-256 digests.
-- The npm registry integrity values were recorded before any execution:
+- The npm registry integrity values were recorded before any execution: `skills@1.5.13`
+  is
+  `sha512-eKYnMYCV4zlmXSikluxctEsn46i9ci18vb2d8b45yb4zTIvj3nFqMV3IrzF7VxqoXPF2AQnEZqVDu9tbPB2Atw==`;
   `skills-ref@0.1.5` is
   `sha512-C2vyZbUQqt3PXA9vcdUmJ0lwbH9jK19C9fwQjl/ICPy2e5bzV3CaropViakJCv+HLt/9zsgjZ/NLJ5xEri0jSA==`;
   `get-tbd@0.3.0` is

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -33,8 +33,8 @@ reviewed separately.
 | Rich | >=15.0.0 | Keep >=15.0.0 | 2026-04-12 | Already latest |
 | basedpyright | >=1.39.6 | **Raise to [>=1.39.9](https://github.com/DetachHead/basedpyright/releases/tag/v1.39.9)** | 2026-06-27 | Canonical DetachHead release; immutable GitHub release |
 | funlog | >=0.2.1 | Keep >=0.2.1 | 2025-03-28 | Canonical `jlevy/funlog`; already latest |
-| Hatchling | unbounded build requirement | **Add >=1.30.1 floor** | 2026-06-02 | Official PyPA backend; 1.31.0 is too fresh |
-| uv-dynamic-versioning | unbounded build requirement | **Add >=0.14.0 floor** | 2026-03-22 | Canonical ninoseki project; already latest |
+| Hatchling | unbounded build requirement | **Pin 1.30.1** | 2026-06-02 | Official PyPA backend; 1.31.0 is too fresh |
+| uv-dynamic-versioning | unbounded build requirement | **Pin 0.14.0** | 2026-03-22 | Canonical ninoseki project; already latest |
 | skills-ref | 0.1.5 | Keep 0.1.5 | 2025-12-27 | Exact npm package and integrity are pinned; already latest |
 | get-tbd | 0.2.3 | Evaluate 0.3.0 separately | 2026-06-15 | Repository-only bootstrap; npm integrity verified before execution |
 
@@ -51,6 +51,12 @@ and is not added to classifiers or CI.
 Full commit pins are used for both actions so workflow review has one consistent rule.
 The generated publish workflow retains only `contents: read` and `id-token: write`; CI
 workflows retain `contents: read`.
+
+`uv build` does not consume `uv.lock` for its isolated build environment.
+The template therefore declares exact reviewed build-system versions, mirrors them in a
+`build` dependency group, syncs that group from `uv.lock`, and builds with
+`--no-build-isolation`. This makes the locked environment, rather than a second resolver
+run, authoritative for release artifacts.
 
 ## Provenance and Advisory Results
 

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -37,7 +37,7 @@ reviewed separately.
 | uv-dynamic-versioning | unbounded build requirement | **Pin 0.14.0** | 2026-03-22 | Canonical ninoseki project; already latest |
 | skills installer | unpinned `npx skills` | **Pin skills 1.5.13** | 2026-06-23 | Canonical Vercel Labs CLI; npm provenance, registry signature, and integrity present |
 | skills-ref | 0.1.5 | Keep 0.1.5 | 2025-12-27 | Exact npm package and integrity are pinned; already latest |
-| get-tbd | 0.2.3 | Evaluate 0.3.0 separately | 2026-06-15 | Repository-only bootstrap; npm integrity verified before execution |
+| get-tbd | 0.2.3 | Defer eligible 0.3.0 | 2026-06-15 | Repository-only bootstrap; the reviewed 142-file source delta is not focused template-release work |
 
 The Python compatibility matrix remains 3.11 through 3.14. Python 3.15 is pre-release
 and is not added to classifiers or CI.
@@ -91,6 +91,11 @@ The following releases were younger than the cutoff and are excluded without exc
 - setup-uv v8.3.1 and v8.3.2
 - Hatchling 1.31.0
 - get-tbd 0.4.0
+
+get-tbd 0.3.0 is eligible, but its source delta introduces the f05/f06 config and
+forkable-docs models and would broadly regenerate repository-only agent artifacts.
+That migration is deferred to `smu-i8xh` after v0.4.0 so it can be reviewed
+independently and coordinated with the existing ensure-gh-cli fix in `smu-r17y`.
 
 `uv audit` remains preview functionality in this uv series.
 It may be used as an additional release-time check, but this release does not make a

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -18,6 +18,8 @@ The audit covers the template inputs, generated-project development and build
 dependencies, repository-only tools, and active GitHub Actions.
 It does not approve transitive packages by implication; the rendered `uv.lock` diff is
 reviewed separately.
+The generated project anchors `exclude-newer = "14 days"` in `[tool.uv]`; Makefile and
+CI environment settings repeat the policy for commands outside project discovery.
 
 ## Frozen Python and Tool Candidates
 

--- a/docs/project/research/research-v0.4.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.4.0-supply-chain-manifest.md
@@ -50,7 +50,11 @@ and is not added to classifiers or CI.
 
 Full commit pins are used for both actions so workflow review has one consistent rule.
 The generated publish workflow retains only `contents: read` and `id-token: write`; CI
-workflows retain `contents: read`.
+workflows retain `contents: read`. setup-uv v8.2.0 does not use the default version
+manifest checksum unless it is also in the action’s built-in checksum table.
+uv 0.11.25 postdates that table, so Linux workflows provide the official
+`uv-x86_64-unknown-linux-gnu` SHA-256 directly:
+`1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2`.
 
 `uv build` does not consume `uv.lock` for its isolated build environment.
 The template therefore declares exact reviewed build-system versions, mirrors them in a

--- a/skills/simple-modern-uv/SKILL.md
+++ b/skills/simple-modern-uv/SKILL.md
@@ -75,7 +75,7 @@ These are never questions.
    Then render, replacing the answer values:
 
    ```bash
-   uvx copier@9.16.0 copy --defaults \
+   UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
      --data package_name=acme-widgets \
      --data "package_description=One-line description" \
      --data "package_author_name=Jane Doe" \
@@ -97,7 +97,7 @@ These are never questions.
    cd acme-widgets
    git init --initial-branch=main
    git add . && git commit -m "Initial commit from simple-modern-uv."
-   uv sync --all-extras
+   make install
    git add uv.lock && git commit -m "Add uv.lock."
    ```
 
@@ -117,7 +117,7 @@ In brief: run the interview with answers **inferred from the repo itself**
 template into a sibling temp directory with those answers, merge the template’s
 structure into the project (preserving its dependencies, metadata, and code), translate
 old tool configs to uv equivalents, write `.copier-answers.yml` so future updates work,
-and verify with `uv sync`, lint, and tests.
+and verify with `make install`, lint, and tests.
 Land everything on a branch as one reviewable change.
 
 ## Workflow 3: Update a Templated Project
@@ -131,7 +131,7 @@ Requires a clean working tree and the project’s `.copier-answers.yml`.
    [references/customize.md](references/customize.md)).
 
 2. ```bash
-   uvx copier@9.16.0 update --defaults --skip-answered
+   UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults --skip-answered
    ```
 
 3. Resolve any `*.rej` files or inline conflict markers, re-run `make lint` and
@@ -140,9 +140,9 @@ Requires a clean working tree and the project’s `.copier-answers.yml`.
 
 ## Verification Gate (All Workflows)
 
-Before reporting success: `uv sync --all-extras`, `make lint`, and `make test` all pass,
-and for publishable packages `uv build` produces a wheel with a sensible version
-(requires at least one git commit; see the FAQ if the version looks wrong).
+Before reporting success: `make install`, `make lint`, and `make test` all pass, and for
+publishable packages `make build` produces a wheel with a sensible version (requires at
+least one git commit; see the FAQ if the version looks wrong).
 Report what you ran and the results.
 
 <!-- This document follows common-doc-guidelines.md.

--- a/skills/simple-modern-uv/SKILL.md
+++ b/skills/simple-modern-uv/SKILL.md
@@ -75,7 +75,7 @@ These are never questions.
    Then render, replacing the answer values:
 
    ```bash
-   UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
+   uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
      --data package_name=acme-widgets \
      --data "package_description=One-line description" \
      --data "package_author_name=Jane Doe" \
@@ -131,7 +131,7 @@ Requires a clean working tree and the project’s `.copier-answers.yml`.
    [references/customize.md](references/customize.md)).
 
 2. ```bash
-   UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults --skip-answered
+   uvx --exclude-newer "14 days" copier@9.16.0 update --defaults --skip-answered
    ```
 
 3. Resolve any `*.rej` files or inline conflict markers, re-run `make lint` and

--- a/skills/simple-modern-uv/SKILL.md
+++ b/skills/simple-modern-uv/SKILL.md
@@ -75,7 +75,7 @@ These are never questions.
    Then render, replacing the answer values:
 
    ```bash
-   uvx copier@9.15.1 copy --defaults \
+   uvx copier@9.16.0 copy --defaults \
      --data package_name=acme-widgets \
      --data "package_description=One-line description" \
      --data "package_author_name=Jane Doe" \
@@ -131,7 +131,7 @@ Requires a clean working tree and the project’s `.copier-answers.yml`.
    [references/customize.md](references/customize.md)).
 
 2. ```bash
-   uvx copier@9.15.1 update --defaults --skip-answered
+   uvx copier@9.16.0 update --defaults --skip-answered
    ```
 
 3. Resolve any `*.rej` files or inline conflict markers, re-run `make lint` and

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -32,7 +32,7 @@ not yours.
 
 ```bash
 cd ..
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
+uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
   --data package_name=<name> ... \
   gh:jlevy/simple-modern-uv <project>-template-render
 ```

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -32,7 +32,7 @@ not yours.
 
 ```bash
 cd ..
-uvx copier@9.15.1 copy --defaults \
+uvx copier@9.16.0 copy --defaults \
   --data package_name=<name> ... \
   gh:jlevy/simple-modern-uv <project>-template-render
 ```

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -32,7 +32,7 @@ not yours.
 
 ```bash
 cd ..
-uvx copier@9.16.0 copy --defaults \
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
   --data package_name=<name> ... \
   gh:jlevy/simple-modern-uv <project>-template-render
 ```
@@ -109,10 +109,10 @@ If legacy code produces a wall of errors, see the FAQ: relax first, ratchet late
 ## Step 4: Lock, Verify, Iterate
 
 ```bash
-uv sync --all-extras       # creates uv.lock; commit it
+make install               # creates uv.lock; commit it
 make lint                  # codespell + ruff + basedpyright
 make test
-uv build                   # only if publishing
+make build                 # only if publishing
 ```
 
 Fix failures using [faq.md](faq.md).

--- a/skills/simple-modern-uv/references/customize.md
+++ b/skills/simple-modern-uv/references/customize.md
@@ -12,7 +12,7 @@ Preferred: set the `package_license` answer (`MIT`, `Apache-2.0`, `BSD-3-Clause`
 re-answer it later with:
 
 ```bash
-uvx copier@9.15.1 update --data package_license=Apache-2.0
+uvx copier@9.16.0 update --data package_license=Apache-2.0
 ```
 
 This updates the `LICENSE` file and the `license` field in `pyproject.toml` together,

--- a/skills/simple-modern-uv/references/customize.md
+++ b/skills/simple-modern-uv/references/customize.md
@@ -12,7 +12,7 @@ Preferred: set the `package_license` answer (`MIT`, `Apache-2.0`, `BSD-3-Clause`
 re-answer it later with:
 
 ```bash
-uvx copier@9.16.0 update --data package_license=Apache-2.0
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=Apache-2.0
 ```
 
 This updates the `LICENSE` file and the `license` field in `pyproject.toml` together,

--- a/skills/simple-modern-uv/references/customize.md
+++ b/skills/simple-modern-uv/references/customize.md
@@ -12,7 +12,7 @@ Preferred: set the `package_license` answer (`MIT`, `Apache-2.0`, `BSD-3-Clause`
 re-answer it later with:
 
 ```bash
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=Apache-2.0
+uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=Apache-2.0
 ```
 
 This updates the `LICENSE` file and the `license` field in `pyproject.toml` together,

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -62,7 +62,7 @@ commit or stash first.
 The project predates the `publish_to_pypi` and `package_license` questions and the
 update filled them with defaults.
 Re-run the update passing the project’s reality, e.g.
-`uvx copier@9.15.1 update --data publish_to_pypi=false`, and see “Reconciling New
+`uvx copier@9.16.0 update --data publish_to_pypi=false`, and see “Reconciling New
 Questions on Update” in [customize.md](customize.md).
 
 ## Publish Workflow Fails with OIDC or Permission Errors

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -62,7 +62,7 @@ commit or stash first.
 The project predates the `publish_to_pypi` and `package_license` questions and the
 update filled them with defaults.
 Re-run the update passing the project’s reality, e.g.
-`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data publish_to_pypi=false`, and
+`uvx --exclude-newer "14 days" copier@9.16.0 update --data publish_to_pypi=false`, and
 see “Reconciling New Questions on Update” in [customize.md](customize.md).
 
 ## Publish Workflow Fails with OIDC or Permission Errors

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -62,8 +62,8 @@ commit or stash first.
 The project predates the `publish_to_pypi` and `package_license` questions and the
 update filled them with defaults.
 Re-run the update passing the project’s reality, e.g.
-`uvx copier@9.16.0 update --data publish_to_pypi=false`, and see “Reconciling New
-Questions on Update” in [customize.md](customize.md).
+`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data publish_to_pypi=false`, and
+see “Reconciling New Questions on Update” in [customize.md](customize.md).
 
 ## Publish Workflow Fails with OIDC or Permission Errors
 

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install all dependencies
         # --frozen: install exactly from the committed uv.lock, never re-resolving
         # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen).
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --all-groups --frozen
 
       - name: Run linting
         # Check-only mode so CI fails on unformatted code instead of fixing it.

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -38,21 +38,23 @@ jobs:
       # https://docs.astral.sh/uv/guides/integration/github/
 
       - name: Checkout (official GitHub action)
-        # Pinned to a full, immutable version tag (see supply-chain notes in
+        # Pinned to a full commit SHA (see supply-chain notes in
         # docs/development.md); bump deliberately when updating.
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Important for versioning plugins:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv (official Astral action)
-        # Pinned to a full, immutable version tag. As of v8, setup-uv no longer
-        # publishes floating major/minor tags (e.g. `@v8`), so bump this exact
-        # version when updating.
-        uses: astral-sh/setup-uv@v8.1.0
+        # Pinned to a full commit SHA. Bump the action, uv version, and Linux
+        # checksum together when updating.
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           # Update this as needed:
           version: "0.11.25"
+          # uv-x86_64-unknown-linux-gnu; update for another matrix OS/arch.
+          checksum: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
@@ -60,8 +62,9 @@ jobs:
         run: uv python install
 
       # Alternately can use the official Python action:
+      # Pin a reviewed full commit SHA before enabling it.
       # - name: Set up Python (using actions/setup-python)
-      #   uses: actions/setup-python@v5
+      #   uses: actions/setup-python@FULL_COMMIT_SHA # reviewed version
       #   with:
       #     python-version: ${{ matrix.python-version }}
 

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           # Update this as needed:
-          version: "0.11.17"
+          version: "0.11.25"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 

--- a/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
+++ b/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
@@ -31,7 +31,7 @@ jobs:
         # Pinned to a full, immutable version tag (see note in ci.yml).
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.17"
+          version: "0.11.25"
           enable-cache: true
           python-version: "3.12"
 

--- a/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
+++ b/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
@@ -20,18 +20,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout (official GitHub action)
-        # Pinned to a full, immutable version tag (see supply-chain notes in
+        # Pinned to a full commit SHA (see supply-chain notes in
         # docs/development.md); bump deliberately when updating.
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Important for versioning plugins:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv (official Astral action)
-        # Pinned to a full, immutable version tag (see note in ci.yml).
-        uses: astral-sh/setup-uv@v8.1.0
+        # Pinned to a full commit SHA (see note in ci.yml).
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.11.25"
+          # uv-x86_64-unknown-linux-gnu.
+          checksum: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
           enable-cache: true
           python-version: "3.12"
 
@@ -52,5 +55,5 @@ jobs:
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always
         # Although uv is newer and faster, the "official" publishing option is the one from PyPA,
-        # which uses twine. If desired, replace `uv publish` with:
-        # uses: pypa/gh-action-pypi-publish@release/v1
+        # which uses twine. If desired, replace `uv publish` with a reviewed full SHA:
+        # uses: pypa/gh-action-pypi-publish@FULL_COMMIT_SHA # reviewed release/v1 commit

--- a/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
+++ b/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
@@ -41,13 +41,13 @@ jobs:
       - name: Install all dependencies
         # --frozen: install exactly from the committed uv.lock, never re-resolving
         # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen).
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --all-groups --frozen
 
       - name: Run tests
         run: uv run pytest
 
       - name: Build package
-        run: uv build
+        run: uv build --no-build-isolation
 
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -11,14 +11,15 @@ This project uses [uv](https://docs.astral.sh/uv/) for Python and dependency man
 The `Makefile` wraps the common commands:
 
 ```bash
-make install     # uv sync --all-extras (install all deps into .venv)
+make install     # uv sync --all-extras --all-groups (install all deps into .venv)
 make lint        # auto-format and lint: codespell, ruff check --fix, ruff format, basedpyright
 make lint-check  # check-only variant, matching CI (fails instead of fixing)
 make test        # uv run pytest
-make build       # uv build (wheel + sdist)
+make build       # locked, non-isolated uv build (wheel + sdist)
 ```
 
-Or call uv directly: `uv run pytest tests/test_foo.py`, `uv add some-package`,
+Or call uv directly: `uv run pytest tests/test_foo.py`,
+`UV_EXCLUDE_NEWER="14 days" uv add some-package`, or
 `uv run python -m {{ package_module }}`.
 
 ## Conventions
@@ -31,7 +32,8 @@ Or call uv directly: `uv run pytest tests/test_foo.py`, `uv add some-package`,
   [basedpyright](https://docs.basedpyright.com/). Settings live in `pyproject.toml`. Run
   `make lint` before committing.
 
-- **Dependencies**: add with `uv add` (runtime) or `uv add --dev` (dev).
+- **Dependencies**: add with `UV_EXCLUDE_NEWER="14 days" uv add` (runtime) or
+  `UV_EXCLUDE_NEWER="14 days" uv add --dev` (dev).
   Commit `uv.lock`. Don’t use pip, poetry, or requirements.txt.
 
 - **Versioning**: the version comes from git tags via dynamic versioning; never edit a

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -19,7 +19,7 @@ make build       # locked, non-isolated uv build (wheel + sdist)
 ```
 
 Or call uv directly: `uv run pytest tests/test_foo.py`,
-`UV_EXCLUDE_NEWER="14 days" uv add some-package`, or
+`uv add --exclude-newer "14 days" some-package`, or
 `uv run python -m {{ package_module }}`.
 
 ## Conventions
@@ -32,8 +32,8 @@ Or call uv directly: `uv run pytest tests/test_foo.py`,
   [basedpyright](https://docs.basedpyright.com/). Settings live in `pyproject.toml`. Run
   `make lint` before committing.
 
-- **Dependencies**: add with `UV_EXCLUDE_NEWER="14 days" uv add` (runtime) or
-  `UV_EXCLUDE_NEWER="14 days" uv add --dev` (dev).
+- **Dependencies**: add with `uv add --exclude-newer "14 days"` (runtime) or
+  `uv add --dev --exclude-newer "14 days"` (dev).
   Commit `uv.lock`. Don’t use pip, poetry, or requirements.txt.
 
 - **Versioning**: the version comes from git tags via dynamic versioning; never edit a

--- a/template/Makefile
+++ b/template/Makefile
@@ -9,7 +9,7 @@
 default: install lint test
 
 install:
-	uv sync --all-extras
+	uv sync --all-extras --all-groups
 
 lint:
 	uv run python devtools/lint.py
@@ -24,8 +24,8 @@ test:
 upgrade:
 	uv sync --upgrade --all-extras --dev
 
-build:
-	uv build
+build: install
+	uv build --no-build-isolation
 
 clean:
 	-rm -rf dist/

--- a/template/Makefile
+++ b/template/Makefile
@@ -4,6 +4,10 @@
 
 .DEFAULT_GOAL := default
 
+# Safe default for every dependency resolution invoked through this Makefile.
+UV_EXCLUDE_NEWER ?= 14 days
+export UV_EXCLUDE_NEWER
+
 .PHONY: default install lint lint-check test upgrade build clean
 
 default: install lint test
@@ -22,7 +26,7 @@ test:
 	uv run pytest
 
 upgrade:
-	uv sync --upgrade --all-extras --dev
+	uv sync --upgrade --all-extras --all-groups
 
 build: install
 	uv build --no-build-isolation

--- a/template/docs/development.md.jinja
+++ b/template/docs/development.md.jinja
@@ -17,9 +17,13 @@ The `Makefile` simply offers shortcuts to `uv` commands for developer convenienc
 (For clarity, GitHub Actions don’t use the Makefile and just call `uv` directly.)
 
 ```shell
+# Apply the supply-chain cool-off to direct uv commands below. The Makefile sets
+# the same default for its recipes; override the variable explicitly if needed.
+export UV_EXCLUDE_NEWER="14 days"
+
 # First, install all dependencies and set up your virtual environment.
-# This simply runs `uv sync --all-extras` to install all packages,
-# including dev dependencies and optional dependencies.
+# This runs `uv sync --all-extras --all-groups` to install runtime, development,
+# optional, and locked build dependencies.
 make install
 
 # Run uv sync, lint, and test:
@@ -60,8 +64,6 @@ uv add --dev package_name
 uv sync --upgrade
 # Update a specific package:
 uv lock --upgrade-package package_name
-# Update dependencies on a package:
-uv add package_name@latest
 
 # Run a shell within the Python environment:
 uv venv
@@ -93,6 +95,11 @@ Its key defaults:
   (absent a documented exception); most malicious publishes are caught within days.
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
   duration like `"14 days"`); this project’s CI workflows set it automatically.
+  The Makefile also defaults to 14 days.
+  Override it explicitly for a stricter window, such as
+  `UV_EXCLUDE_NEWER="30 days" make upgrade`. A reviewed emergency exception must be
+  equally explicit, using `UV_EXCLUDE_NEWER="0 days"` only for that invocation and
+  recording why the normal gate was bypassed.
 
 - **Vet before adding:** Confirm the package is actually needed and its name is spelled
   correctly (typosquats are common), and prefer a little first-party code over a new

--- a/template/docs/development.md.jinja
+++ b/template/docs/development.md.jinja
@@ -94,8 +94,8 @@ Its key defaults:
 - **Cool-off period:** Don’t install or upgrade to a release less than 14 days old
   (absent a documented exception); most malicious publishes are caught within days.
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this project’s CI workflows set it automatically.
-  The Makefile also defaults to 14 days.
+  duration like `"14 days"`); this project sets it in `pyproject.toml`, CI, and the
+  Makefile so direct commands and standard workflows default to the same policy.
   Override it explicitly for a stricter window, such as
   `UV_EXCLUDE_NEWER="30 days" make upgrade`. A reviewed emergency exception must be
   equally explicit, using `UV_EXCLUDE_NEWER="0 days"` only for that invocation and

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,7 +15,7 @@ readme = "README.md"
 {%- if package_license == 'None' %}
 # No license chosen yet. When you pick one, set an SPDX expression here and add a
 # LICENSE file, or re-answer the template question:
-# UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=MIT
+# uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=MIT
 {%- else %}
 license = "{{ 'LicenseRef-Proprietary' if package_license == 'Proprietary' else package_license }}"
 {%- endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -57,13 +57,17 @@ dependencies = [
 # ---- Dev dependencies ----
 
 [dependency-groups]
+build = [
+    "hatchling==1.30.1",
+    "uv-dynamic-versioning==0.14.0",
+]
 dev = [
-    "pytest>=9.0.3",
+    "pytest>=9.1.1",
     "pytest-sugar>=1.1.1",
-    "ruff>=0.15.15",
+    "ruff>=0.15.20",
     "codespell>=2.4.2",
     "rich>=15.0.0",
-    "basedpyright>=1.39.6",
+    "basedpyright>=1.39.9",
     "funlog>=0.2.1",
 ]
 
@@ -78,7 +82,7 @@ dev = [
 # https://github.com/ninoseki/uv-dynamic-versioning/
 
 [build-system]
-requires = ["hatchling", "uv-dynamic-versioning"]
+requires = ["hatchling==1.30.1", "uv-dynamic-versioning==0.14.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,7 +15,7 @@ readme = "README.md"
 {%- if package_license == 'None' %}
 # No license chosen yet. When you pick one, set an SPDX expression here and add a
 # LICENSE file, or re-answer the template question:
-# uvx copier update --data package_license=MIT
+# UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --data package_license=MIT
 {%- else %}
 license = "{{ 'LicenseRef-Proprietary' if package_license == 'Proprietary' else package_license }}"
 {%- endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -105,9 +105,11 @@ packages = ["src/{{ package_module }}"]
 
 [tool.uv]
 # Fail fast on old uv versions rather than misbehave. 0.9 is the floor where
-# UV_EXCLUDE_NEWER accepts a relative duration like "14 days" (used in CI for the
-# supply-chain cool-off; see docs/development.md).
+# exclude-newer accepts a relative duration like "14 days".
 required-version = ">=0.9"
+# Safe project-level default for every uv command. CI and the Makefile repeat it so
+# copied commands and tool execution outside project discovery retain the same policy.
+exclude-newer = "14 days"
 
 [tool.ruff]
 # Set as desired, typically 88 (black standard) or 100 (wide).

--- a/updating.md
+++ b/updating.md
@@ -34,29 +34,97 @@ If downstream then fails, fix forward with a patch release.
 
 ## Step 1: Check Latest Versions
 
-From the template repo, check what’s current on PyPI:
+Take one timestamped inventory, calculate the exact cutoff, and freeze it for the
+release. Do not keep chasing releases while implementing.
+This standard-library script prints both the latest stable numeric release and the
+newest non-yanked release that is eligible at the cutoff:
 
 ```shell
-# Check latest versions of each dev dependency:
-for pkg in ruff basedpyright pytest pytest-sugar codespell rich funlog; do
-  echo "$pkg: $(curl -s https://pypi.org/pypi/$pkg/json | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")"
-done
+python3 - <<'PY'
+import datetime as dt
+import json
+import re
+import urllib.request
 
-# Check latest uv version:
-curl -s https://pypi.org/pypi/uv/json | python3 -c "import sys,json; print('uv:', json.load(sys.stdin)['info']['version'])"
+packages = [
+    "uv", "copier", "flowmark-rs", "pytest", "pytest-sugar", "ruff",
+    "codespell", "rich", "basedpyright", "funlog", "hatchling",
+    "uv-dynamic-versioning",
+]
+now = dt.datetime.now(dt.timezone.utc)
+cutoff = now - dt.timedelta(days=14)
+stable = re.compile(r"^[0-9]+(?:\.[0-9]+)*$")
+print(f"audit={now.isoformat()} cutoff={cutoff.isoformat()}")
+
+for package in packages:
+    url = f"https://pypi.org/pypi/{package}/json"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        data = json.load(response)
+    releases = []
+    for version, files in data["releases"].items():
+        if not stable.fullmatch(version):
+            continue
+        timestamps = [
+            dt.datetime.fromisoformat(
+                file["upload_time_iso_8601"].replace("Z", "+00:00")
+            )
+            for file in files
+            if not file.get("yanked")
+        ]
+        if timestamps:
+            key = tuple(map(int, version.split(".")))
+            releases.append((key, version, min(timestamps)))
+    latest = max(releases)
+    eligible = max(release for release in releases if release[2] <= cutoff)
+    print(
+        f"{package:24} eligible={eligible[1]:12} {eligible[2].isoformat()} "
+        f"latest={latest[1]:12} {latest[2].isoformat()}"
+    )
+
+for package in ["skills", "skills-ref", "get-tbd"]:
+    url = f"https://registry.npmjs.org/{package}"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        data = json.load(response)
+    releases = []
+    for version, metadata in data["versions"].items():
+        if not stable.fullmatch(version):
+            continue
+        published = dt.datetime.fromisoformat(
+            data["time"][version].replace("Z", "+00:00")
+        )
+        key = tuple(map(int, version.split(".")))
+        releases.append((key, version, published, metadata))
+    latest = max(releases)
+    eligible = max(release for release in releases if release[2] <= cutoff)
+    distribution = eligible[3]["dist"]
+    print(
+        f"npm:{package:20} eligible={eligible[1]:12} {eligible[2].isoformat()} "
+        f"latest={latest[1]:12} integrity={distribution['integrity']} "
+        f"provenance={bool(distribution.get('attestations'))}"
+    )
+PY
 ```
 
-Also check for new major versions of GitHub Actions:
+The npm section inventories the executable tools (`skills`, `skills-ref`, and `get-tbd`)
+with registry timestamps, integrity, and provenance metadata.
+Also verify each canonical repository.
+Apply the same cutoff to direct and transitive packages and disable lifecycle scripts.
+
+Check GitHub Action releases and their tag targets:
+
 - `actions/checkout`: <https://github.com/actions/checkout/releases>
 - `astral-sh/setup-uv`: <https://github.com/astral-sh/setup-uv/releases>
 
-Note the actions are pinned to full, immutable version tags (e.g.
-`actions/checkout@v6.0.2`, `astral-sh/setup-uv@v8.1.0`) rather than floating major tags.
-As of v8, Astral stopped publishing floating `@v8`/`@v8.1` tags in favor of immutable
-releases, which is a supply-chain improvement (a pinned tag can’t be silently
-re-pointed). The cost is that patch updates no longer arrive automatically, so bump the
-exact version here when updating.
-Apply the cooling-off check below to the action version too.
+Pin every active action to its full commit SHA and keep the reviewed version in a
+comment.
+An exact version tag is not necessarily immutable: checkout v7.0.0, for example,
+was published as a non-immutable release.
+For setup-uv, inspect whether the selected uv version is in the action’s built-in
+checksum table; when it is not, pass the official platform checksum through the action’s
+`checksum` input. Review major-action runtime requirements too: checkout v7 uses Node 24
+and requires Actions Runner v2.327.1 or newer.
+GitHub-hosted runners satisfy this; self-hosted runners must be upgraded before adopting
+it.
 
 And check if new Python versions should be added to the test matrix.
 
@@ -72,15 +140,15 @@ days. Fresh releases are the most likely to be yanked, to carry regressions, or 
 to be a compromised/typosquatted artifact that hasn’t yet been caught.
 Prefer the latest version that is both at least 14 days old and has had subsequent patch
 releases without being yanked.
-The CI and publish workflows enforce this by setting `UV_EXCLUDE_NEWER` to a 14-day
-cool-off window (the pinned uv accepts the relative duration `"14 days"` directly).
+The CI, generated Makefile, and repository Makefile enforce this by setting
+`UV_EXCLUDE_NEWER` to a 14-day cool-off window (the pinned uv accepts the relative
+duration `"14 days"` directly).
 
-Concretely, for each package, check the upload date before pinning:
-
-```shell
-# Show the latest version and its upload date for a package:
-curl -s https://pypi.org/pypi/PACKAGE/json | python3 -c "import sys,json; d=json.load(sys.stdin); v=d['info']['version']; print(v, d['releases'][v][0]['upload_time_iso_8601'])"
-```
+For every changed item, verify the canonical repository and maintainer, inspect all
+intervening release notes and source changes, record registry hashes or attestations,
+confirm the release is not yanked, and query OSV or the relevant advisory database.
+Then inspect the entire rendered lockfile diff; a clean direct-package query does not
+approve changed transitive packages.
 
 Only add or upgrade dependencies you can vet upstream (active maintenance, reputable
 source, clear changelog).
@@ -92,18 +160,29 @@ In the template repo, update these files as needed:
 
 - **Dev dependency lower bounds** in `template/pyproject.toml.jinja` (these are `>=`
   floors, not exact pins; CI enforces the cool-off via `UV_EXCLUDE_NEWER`)
+- **Build backend pins** in both `[build-system].requires` and the locked `build`
+  dependency group. Keep the generated non-isolated build path in sync so release
+  artifacts use the lockfile-resolved graph
 - **uv version** in `template/.github/workflows/ci.yml` and `publish.yml` (the
   `version:` field under `astral-sh/setup-uv`), and the matching `UV_VERSION` in this
-  repo’s own `.github/workflows/ci.yml`
-- **GitHub Actions versions** (e.g. `actions/checkout@v6.0.2`) in the same workflow
-  files, and in this repo’s own `.github/workflows/ci.yml`
+  repo’s own `.github/workflows/ci.yml`. Update the official platform checksum beside
+  every pin
+- **GitHub Action full commit SHAs** and version comments in the same workflow files and
+  in this repo’s own `.github/workflows/ci.yml`; keep `persist-credentials: false` where
+  no later step pushes
 - **Python version matrix** in `template/.github/workflows/ci.yml` and the corresponding
   classifiers in `template/pyproject.toml.jinja`
 - **The agent skill** (`skills/simple-modern-uv/`): keep the pinned `uvx copier@X.Y.Z`
   invocations current (subject to the same cool-off), and update the FAQ/checklists if
   this cycle changed behavior they describe
+- **Executable npm tools** in the README and CI: pin exact versions, preserve the frozen
+  `before` cutoff, disable lifecycle scripts, and record registry integrity/provenance
+- **Safe-default Makefile paths**: keep the 14-day default on install, upgrade, format,
+  and build commands, while preserving an explicit per-invocation override
 - Review `docs/project/research/research-uv-changes.md` for new uv features the template
   should adopt or explicitly decline
+- Record the complete frozen decision in a release-specific supply-chain manifest under
+  `docs/project/research/`
 
 ### Changing Template Questions (Answer-Schema Evolution)
 
@@ -131,7 +210,8 @@ make format        # auto-format all Markdown docs, including *.md.jinja templat
 make format-check  # check-only, to confirm nothing is left unformatted
 ```
 
-This runs the pinned `uvx flowmark-rs@0.3.1 --auto` from the top-level `Makefile`.
+This runs the pinned `uvx flowmark-rs@0.3.1 --auto` from the top-level `Makefile`, which
+also applies the 14-day resolver gate by default.
 
 ## Step 3: Commit and Push the Template Candidate
 
@@ -158,7 +238,8 @@ git status --short
 
 # Export the exact template candidate. This uses the _src_path already recorded in
 # .copier-answers.yml, currently gh:jlevy/simple-modern-uv.
-copier update --defaults --vcs-ref "$TEMPLATE_COMMIT"
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults \
+  --vcs-ref "$TEMPLATE_COMMIT"
 git diff --stat
 ```
 
@@ -166,7 +247,8 @@ If the downstream repo ever needs a fresh render instead of an update, instantia
 the standard defaults:
 
 ```shell
-copier copy --defaults --vcs-ref "$TEMPLATE_COMMIT" gh:jlevy/simple-modern-uv .
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
+  --vcs-ref "$TEMPLATE_COMMIT" gh:jlevy/simple-modern-uv .
 ```
 
 ## Step 5: Verify Locally
@@ -175,12 +257,12 @@ After the copier update, confirm everything works locally.
 Use the same 14-day supply-chain cool-off the GitHub workflows set.
 
 ```shell
-export UV_EXCLUDE_NEWER="14 days"
-
-uv sync --all-extras
-uv run python devtools/lint.py --check
-uv run pytest
-uv build
+make install
+make lint-check
+make test
+make build
+UV_EXCLUDE_NEWER="14 days" uvx uv@0.11.25 audit --locked \
+  --preview-features audit-command
 ```
 
 ## Step 6: Push Downstream and Confirm CI
@@ -226,11 +308,11 @@ create a GitHub release on the template repo.
 
 Pick the version by what changed:
 
-- **Minor** (`v0.3.0`): new or changed template questions, new files in the render, or
-  other feature-level changes.
+- **Minor** (`v0.4.0`): new or changed template questions, new files or dependency
+  groups in the render, or other feature-level changes.
   Per the answer-schema policy above, the release notes must name any new question keys
   and their defaults.
-- **Patch** (`v0.2.28`): routine dependency and tool-version bumps, doc fixes, and
+- **Patch** (`v0.3.1`): routine dependency and tool-version bumps, doc fixes, and
   changes that leave the render’s shape alone.
 
 Review the changes and author the release notes as a file first (the gitignored `tmp/`
@@ -264,8 +346,8 @@ a statement of what validation backed the release, and the
 
 Afterwards, verify the release: the tag points at `$TEMPLATE_COMMIT`
 (`gh release view "$NEW_TAG" --json tagName,targetCommitish,isDraft`) and a fresh
-`copier copy gh:jlevy/simple-modern-uv` records the new tag as `_commit` in
-`.copier-answers.yml`.
+`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy gh:jlevy/simple-modern-uv` records
+the new tag as `_commit` in `.copier-answers.yml`.
 
 ## Step 8: Record the Release Tag Downstream
 
@@ -276,7 +358,8 @@ This should either be a no-op or only change `_commit`.
 
 ```shell
 cd ../simple-modern-uv-template
-copier update --defaults --vcs-ref "$NEW_TAG"
+UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults \
+  --vcs-ref "$NEW_TAG"
 git diff -- .copier-answers.yml
 
 git add -A

--- a/updating.md
+++ b/updating.md
@@ -242,7 +242,7 @@ git status --short
 
 # Export the exact template candidate. This uses the _src_path already recorded in
 # .copier-answers.yml, currently gh:jlevy/simple-modern-uv.
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults \
+uvx --exclude-newer "14 days" copier@9.16.0 update --defaults \
   --vcs-ref "$TEMPLATE_COMMIT"
 git diff --stat
 ```
@@ -251,7 +251,7 @@ If the downstream repo ever needs a fresh render instead of an update, instantia
 the standard defaults:
 
 ```shell
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy --defaults \
+uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
   --vcs-ref "$TEMPLATE_COMMIT" gh:jlevy/simple-modern-uv .
 ```
 
@@ -265,7 +265,7 @@ make install
 make lint-check
 make test
 make build
-UV_EXCLUDE_NEWER="14 days" uvx uv@0.11.25 audit --locked \
+uvx --exclude-newer "14 days" uv@0.11.25 audit --locked \
   --preview-features audit-command
 ```
 
@@ -350,8 +350,8 @@ a statement of what validation backed the release, and the
 
 Afterwards, verify the release: the tag points at `$TEMPLATE_COMMIT`
 (`gh release view "$NEW_TAG" --json tagName,targetCommitish,isDraft`) and a fresh
-`UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 copy gh:jlevy/simple-modern-uv` records
-the new tag as `_commit` in `.copier-answers.yml`.
+`uvx --exclude-newer "14 days" copier@9.16.0 copy gh:jlevy/simple-modern-uv` records the
+new tag as `_commit` in `.copier-answers.yml`.
 
 ## Step 8: Record the Release Tag Downstream
 
@@ -362,7 +362,7 @@ This should either be a no-op or only change `_commit`.
 
 ```shell
 cd ../simple-modern-uv-template
-UV_EXCLUDE_NEWER="14 days" uvx copier@9.16.0 update --defaults \
+uvx --exclude-newer "14 days" copier@9.16.0 update --defaults \
   --vcs-ref "$NEW_TAG"
 git diff -- .copier-answers.yml
 

--- a/updating.md
+++ b/updating.md
@@ -140,9 +140,11 @@ days. Fresh releases are the most likely to be yanked, to carry regressions, or 
 to be a compromised/typosquatted artifact that hasn’t yet been caught.
 Prefer the latest version that is both at least 14 days old and has had subsequent patch
 releases without being yanked.
-The CI, generated Makefile, and repository Makefile enforce this by setting
-`UV_EXCLUDE_NEWER` to a 14-day cool-off window (the pinned uv accepts the relative
-duration `"14 days"` directly).
+Generated `pyproject.toml`, CI, the generated Makefile, and the repository Makefile
+enforce a 14-day cool-off window (the pinned uv accepts the relative duration
+`"14 days"` directly).
+Keep the project setting as the primary safe default for direct uv commands; environment
+variables remain explicit per-invocation overrides.
 
 For every changed item, verify the canonical repository and maintainer, inspect all
 intervening release notes and source changes, record registry hashes or attestations,
@@ -179,6 +181,8 @@ In the template repo, update these files as needed:
   `before` cutoff, disable lifecycle scripts, and record registry integrity/provenance
 - **Safe-default Makefile paths**: keep the 14-day default on install, upgrade, format,
   and build commands, while preserving an explicit per-invocation override
+- **The project-level uv policy**: keep `tool.uv.exclude-newer = "14 days"` so direct uv
+  commands cannot silently omit the cool-off
 - Review `docs/project/research/research-uv-changes.md` for new uv features the template
   should adopt or explicitly decline
 - Record the complete frozen decision in a release-specific supply-chain manifest under


### PR DESCRIPTION
## Summary

- update the frozen, 14-day-eligible uv, Copier, pytest, Ruff, and basedpyright versions
- pin GitHub Actions to reviewed full commit SHAs, disable persisted checkout credentials, and verify the uv download with its official SHA-256
- exact-pin build backends, include them in the locked build group, and build non-isolated from that environment
- enforce the 14-day resolver policy in generated project configuration, Makefiles, CI, and executable documentation paths
- add a timestamped supply-chain manifest and reproducible maintenance workflow for future releases

## Why

This prepares the focused v0.4.0 minor release so newly rendered projects start with current eligible tooling without adopting releases younger than two weeks. It also closes gaps where direct uv commands, mutable action tags, unpinned runners, or isolated build resolution could bypass the documented policy.

## Validation

- fresh default, proprietary/no-publish, and no-license renders
- clean Copier update from v0.3.0 with convergence to a fresh render and explicit answer override coverage
- Python 3.11, 3.12, 3.13, and 3.14 tests
- codespell, Ruff check/format, and basedpyright
- locked, non-isolated sdist and wheel build
- uv audit: no known vulnerabilities across 24 third-party packages
- 136 locked PyPI artifacts verified non-yanked, at or before the frozen cutoff, and matching recorded SHA-256 hashes
- Markdown formatting, workflow YAML parsing, and agent-skill validation

The eligible get-tbd 0.3.0 repository bootstrap migration is intentionally deferred: its 142-file f05/f06 and forkable-docs delta is unrelated to generated-project currency and is tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/publish workflows, dependency resolution defaults, and the release build path for all future renders; supply-chain controls are intentional but behavior changes (cool-off, non-isolated builds) need downstream validation.
> 
> **Overview**
> Prepares the **v0.4.0** minor release by freezing 14-day-eligible tool versions and tightening how generated projects resolve, install, and build dependencies.
> 
> **Supply chain and tooling:** Bumps pinned **uv** (0.11.25), **Copier** (9.16.0), and dev-tool floors (pytest, Ruff, basedpyright). Adds a frozen **v0.4.0 supply-chain manifest** and expands **updating.md** with a reproducible audit script and release checklist. Pins **npm** skill installer usage and hardens **skill-validate** CI with script ignore and a frozen `before` cutoff.
> 
> **Generated projects:** Sets **`[tool.uv] exclude-newer = "14 days"`** and exports **`UV_EXCLUDE_NEWER`** from Makefiles (template repo and rendered project). Documents **`uvx`/`uv add --exclude-newer`** and **`make install`** instead of raw `uv sync` across README, skill, and **copier** post-copy messages.
> 
> **CI and Actions:** Pins **actions/checkout** and **setup-uv** to full commit SHAs, disables **persist-credentials**, verifies **uv** with the official Linux checksum, and syncs with **`--all-groups`**. Release builds use **`uv build --no-build-isolation`**.
> 
> **Build graph:** Exact-pins **hatchling** and **uv-dynamic-versioning** in **`[build-system]`** and a new locked **`build` dependency group** so wheels/sdists come from **`uv.lock`**, not an isolated build resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69266fba53677b1a904f3afd568ccfc1ab735e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->