### PR TITLE
feat: refresh uv and agent adoption workflows

### DIFF
--- a/.github/fixtures/ruff-markdown-input.txt
+++ b/.github/fixtures/ruff-markdown-input.txt
@@ -1,0 +1,8 @@
+# Ruff Markdown Review Fixture
+
+This fixture contains a deliberately unformatted Python fence. Template CI copies it
+under `tests/` with a `.md` extension to prove that Ruff leaves Markdown to Flowmark.
+
+```python
+values={"one":1,"two":2}
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           test -f uv.toml
           grep -q '## Working with a Coding Agent' README.md
           grep -q 'simple-modern-uv/tree/main/skills/simple-modern-uv' AGENTS.md
-          grep -q 'required-version = ">=0.9"' uv.toml
+          grep -q 'required-version = ">=0.12.0,<0.13"' uv.toml
           grep -q 'exclude-newer = "14 days"' uv.toml
           ! grep -q '^\[tool\.uv\]' pyproject.toml
           grep -q 'UV_CONFIG_FILE := .*uv.toml' Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           test -f AGENTS.md
           test -f CLAUDE.md
           test -f uv.toml
+          grep -q '## Working With a Coding Agent' README.md
+          grep -q 'simple-modern-uv/tree/main/skills/simple-modern-uv' AGENTS.md
           grep -q 'required-version = ">=0.9"' uv.toml
           grep -q 'exclude-newer = "14 days"' uv.toml
           ! grep -q '^\[tool\.uv\]' pyproject.toml
@@ -213,6 +215,8 @@ jobs:
           NPM_CONFIG_IGNORE_SCRIPTS: "true"
           NPM_CONFIG_BEFORE: "2026-06-29T03:27:33Z"
         run: npx --yes skills-ref@0.1.5 validate skills/simple-modern-uv
+      - name: Check agent installation selects this repository's public skill
+        run: grep -q -- '--skill simple-modern-uv --yes' README.md
       - name: Check that relative links in skill docs resolve
         run: |
           cd skills/simple-modern-uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           test -f AGENTS.md
           test -f CLAUDE.md
           test -f uv.toml
-          grep -q '## Working With a Coding Agent' README.md
+          grep -q '## Working with a Coding Agent' README.md
           grep -q 'simple-modern-uv/tree/main/skills/simple-modern-uv' AGENTS.md
           grep -q 'required-version = ">=0.9"' uv.toml
           grep -q 'exclude-newer = "14 days"' uv.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
         run: |
           cd /tmp/render
           export UV_CONFIG_FILE="$PWD/uv.toml"
+          mkdir -p tests/review-fixtures
+          cp "$GITHUB_WORKSPACE/.github/fixtures/ruff-markdown-input.txt" \
+            tests/review-fixtures/ruff-markdown.md
           uv run python devtools/lint.py --check
           uv run pytest
           git tag v0.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ permissions:
 env:
   # Pinned tool versions used to exercise the template. Keep the uv version in
   # sync with template/.github/workflows/ci.yml when updating.
-  UV_VERSION: "0.11.25"
-  UV_CHECKSUM: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
-  COPIER_SPEC: "copier@9.16.0"
+  UV_VERSION: "0.12.0"
+  UV_CHECKSUM: "eaf842262aa1c418d8ecc5605f02ee1ebfd369124fa48548e85f9481a47831a9"
+  COPIER_SPEC: "copier@9.17.0"
   # Default answers for test renders.
   RENDER_ARGS: >-
     --data package_name=smoke-test
@@ -32,13 +32,14 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: ${{ env.UV_VERSION }}
           checksum: ${{ env.UV_CHECKSUM }}
+          enable-cache: false
       - name: Check doc formatting
         run: make format-check
 
@@ -58,15 +59,18 @@ jobs:
       # template's own CI and the Makefile default (see updating.md).
       UV_EXCLUDE_NEWER: "14 days"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: ${{ env.UV_VERSION }}
           checksum: ${{ env.UV_CHECKSUM }}
           enable-cache: true
+          # setup-uv v9 defaults to retaining wheels to reduce PyPI load. Keep
+          # that tradeoff explicit so a future action default cannot change it.
+          prune-cache: false
           python-version: "3.12"
 
       - name: Render template (${{ matrix.variant }})
@@ -85,6 +89,13 @@ jobs:
               head -1 LICENSE | grep -q "MIT License"
               # Only the commented-out form may appear in the default render:
               ! grep -qE '^\s*"Private :: Do Not Upload",' pyproject.toml
+              grep -q 'uv sync --locked --all-extras --all-groups' \
+                .github/workflows/ci.yml
+              grep -q 'uv sync --locked --all-extras --all-groups' \
+                .github/workflows/publish.yml
+              grep -q 'UV_CONFIG_FILE: uv.toml' .github/workflows/ci.yml
+              grep -q 'UV_CONFIG_FILE: uv.toml' .github/workflows/publish.yml
+              grep -q 'enable-cache: false' .github/workflows/publish.yml
               ;;
             no-publish-proprietary)
               test ! -e .github/workflows/publish.yml
@@ -101,6 +112,11 @@ jobs:
           esac
           test -f AGENTS.md
           test -f CLAUDE.md
+          test -f uv.toml
+          grep -q 'required-version = ">=0.9"' uv.toml
+          grep -q 'exclude-newer = "14 days"' uv.toml
+          ! grep -q '^\[tool\.uv\]' pyproject.toml
+          grep -q 'UV_CONFIG_FILE := .*uv.toml' Makefile
           grep -q '@AGENTS.md' CLAUDE.md
           test -f .copier-answers.yml
 
@@ -109,10 +125,12 @@ jobs:
         # dynamic versioning gives the editable install a real version.
         run: |
           cd /tmp/render
+          export UV_CONFIG_FILE="$PWD/uv.toml"
           git init -q --initial-branch=main
           git add -A
           git -c user.email=ci@example.com -c user.name=CI commit -qm "Initial commit"
           uv sync --all-extras --all-groups
+          uv sync --locked --all-extras --all-groups
           V=$(uv run python -c "from importlib.metadata import version; print(version('smoke-test'))")
           echo "installed version: $V"
           test "$V" != "0.0.0"
@@ -120,6 +138,7 @@ jobs:
       - name: Lint, test, build
         run: |
           cd /tmp/render
+          export UV_CONFIG_FILE="$PWD/uv.toml"
           uv run python devtools/lint.py --check
           uv run pytest
           git tag v0.1.0
@@ -135,14 +154,15 @@ jobs:
     env:
       UV_EXCLUDE_NEWER: "14 days"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: ${{ env.UV_VERSION }}
           checksum: ${{ env.UV_CHECKSUM }}
+          enable-cache: false
 
       - name: Render from previous release tag
         run: |
@@ -185,7 +205,7 @@ jobs:
   skill-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Validate skill structure and frontmatter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ actions rather than telling them to run commands.
 
 <!-- END TBD INTEGRATION -->
 
-## Build & Test
+## Build and Test
 
 This is a [Copier](https://copier.readthedocs.io) template repo, not a Python project
 itself; there is no `pyproject.toml` to sync at the root.
@@ -44,18 +44,25 @@ uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults --vcs-ref=HEAD \
   use, not this repo.
 - `copier.yml`: template questions and validation; the single source of truth for
   template variables.
-- `skills/simple-modern-uv/`: the portable agent workflow bundle.
-  `SKILL.md` is the concise router; its one-level `references/` files own the procedures
-  for new, selective, migration, and update workflows.
-  Keep README discovery and generated agent guidance aligned with these routes.
-- `updating.md`: the full maintenance and release flow (downstream
+- [`skills/simple-modern-uv/`](skills/simple-modern-uv/): the portable agent workflow
+  bundle. Its [`SKILL.md`](skills/simple-modern-uv/SKILL.md) is the concise router; the
+  one-level `references/` files own the new, selective, migration, and update
+  procedures. Keep README discovery and generated agent guidance aligned with these
+  routes.
+- [`updating.md`](updating.md): the full maintenance and release flow (downstream
   `jlevy/simple-modern-uv-template` repo is the release gate).
-- `docs/project/`: research docs and plan specs for this repo.
+- [`docs/project/`](docs/project/README.md): maintainer research, frozen release
+  evidence, and implementation records.
 
-## Conventions & Patterns
+## Conventions and Patterns
 
-- Follow the supply-chain rules in `updating.md`: 14-day cooling-off before adopting new
-  releases, pinned tool versions, `UV_EXCLUDE_NEWER` in workflows.
+- Follow the [supply-chain rules](updating.md#supply-chain-hygiene): 14-day cooling-off
+  before adopting new releases, pinned tool versions, and `UV_EXCLUDE_NEWER` in
+  workflows.
 - Markdown is formatted with flowmark via `make format`; run it before committing doc
   changes.
 - Docs follow common-doc-guidelines (see footer comments in each doc).
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults --vcs-ref=HEAD \
   use, not this repo.
 - `copier.yml`: template questions and validation; the single source of truth for
   template variables.
+- `skills/simple-modern-uv/`: the portable agent workflow bundle.
+  `SKILL.md` is the concise router; its one-level `references/` files own the procedures
+  for new, selective, migration, and update workflows.
+  Keep README discovery and generated agent guidance aligned with these routes.
 - `updating.md`: the full maintenance and release flow (downstream
   `jlevy/simple-modern-uv-template` repo is the release gate).
 - `docs/project/`: research docs and plan specs for this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ make format
 make format-check
 
 # Render the template non-interactively (smoke test):
-uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults --vcs-ref=HEAD \
+uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults --vcs-ref=HEAD \
   --data package_name=smoke-test \
   --data package_github_org=testorg . /tmp/smoke-test
 # Then inside the render: make install && make lint-check && make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,20 @@ make format
 make format-check
 
 # Render the template non-interactively (smoke test):
+SMOKE_DIR=$(mktemp -d)
 uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults --vcs-ref=HEAD \
   --data package_name=smoke-test \
-  --data package_github_org=testorg . /tmp/smoke-test
-# Then inside the render: make install && make lint-check && make test
+  --data package_github_org=testorg . "$SMOKE_DIR"
+
+# Dynamic versioning needs an initial commit before installation:
+cd "$SMOKE_DIR"
+git init --initial-branch=main
+git add .
+git -c user.name=Smoke -c user.email=smoke@example.com \
+  commit -m "Initial commit"
+make install
+make lint-check
+make test
 ```
 
 ## Architecture Overview

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ UV_EXCLUDE_NEWER ?= 14 days
 export UV_EXCLUDE_NEWER
 
 # Pinned for reproducibility and supply-chain hygiene (see updating.md).
-FLOWMARK := uvx flowmark-rs@0.3.1
+FLOWMARK := uvx flowmark-rs@0.3.2
 
 # Format all Markdown docs, including *.md.jinja templates. Excluded paths
 # (tool-managed dirs, attic/) live in .flowmarkignore.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Install the [skill](skills/simple-modern-uv/SKILL.md) (the
 Codex, Cursor, Gemini CLI, and 50+ other agents):
 
 ```shell
-NPM_CONFIG_IGNORE_SCRIPTS=true NPM_CONFIG_BEFORE=2026-06-29T03:27:33Z \
-  npx --yes skills@1.5.13 add jlevy/simple-modern-uv
+NPM_CONFIG_IGNORE_SCRIPTS=true NPM_CONFIG_BEFORE=2026-07-31T18:59:05Z \
+  npx --yes skills@1.5.18 add jlevy/simple-modern-uv
 ```
 
 Then tell your agent what you want, for example:
@@ -293,7 +293,7 @@ License and publishing are template questions, not hand edits: `package_license`
 decide later) and `publish_to_pypi` (answer no for a private package; the publish
 workflow and docs are then omitted).
 Answer them at render time or change them later with
-`uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=…`; see the
+`uvx --exclude-newer "14 days" copier@9.17.0 update --data package_license=…`; see the
 skill’s [customize guide](skills/simple-modern-uv/references/customize.md) for details.
 Prefer re-answering over hand-deleting generated files like `publish.yml`, so future
 `copier update` runs stay consistent.
@@ -330,7 +330,7 @@ cd ~/projects/github   # Wherever you do your project work.
 # Clone this template under the supply-chain cool-off. This does everything!
 # It will fetch from this GitHub repo and create a new directory
 # with whatever name you put below:
-uvx --exclude-newer "14 days" copier@9.16.0 copy \
+uvx --exclude-newer "14 days" copier@9.17.0 copy \
   gh:jlevy/simple-modern-uv YOURNEWREPO
 # Then follow the instructions.
 ```
@@ -351,7 +351,7 @@ git add .
 git commit -m "Initial commit from simple-modern-uv."
 # Sync after the first commit so dynamic versioning gives the editable install
 # a real version (not 0.0.0). This creates uv.lock; commit it so CI installs
-# reproducibly with --frozen.
+# reproducibly with --locked and verifies the lockfile is current.
 make install
 git add uv.lock
 git commit -m "Add uv.lock."
@@ -430,8 +430,9 @@ follows:
 - **Cooling-off period:** Don’t install or upgrade to a release less than 14 days old
   (most malicious publishes are caught within days).
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this template sets it in generated `pyproject.toml`, CI,
-  and the Makefile.
+  duration like `"14 days"`); this template sets it in generated `uv.toml`, CI, and the
+  Makefile. Standard workflows select that checked-in file explicitly so ambient user
+  settings cannot make `uv.lock` nonportable.
 
 - **Vet what you add:** Only add dependencies you can verify upstream, and prefer a
   little first-party code over pulling in a new dependency.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Appropriately enough, the comic is out of date.)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-border.json)](https://github.com/copier-org/copier)
 
-## What is This?
+## What Is This?
 
 **simple-modern-uv** is a minimal, modern **Python project template** for new projects
 (Python 3.11–3.14) based on [**uv**](https://docs.astral.sh/uv/). This template aims to
@@ -20,12 +20,13 @@ It can also upgrade an existing project to a modern setup: uv, ruff, BasedPyrigh
 GitHub Actions, or add only the practices that fit without forcing a full migration.
 The [agent skill](#use-with-any-coding-agent) handles each adoption path.
 
-## Use With Any Coding Agent
+## Use with Any Coding Agent
 
-Install the [simple-modern-uv skill bundle](skills/simple-modern-uv/SKILL.md) and
-appoint your coding agent to do the work.
-It follows the [Agent Skills](https://agentskills.io) open standard, so it works with
-Claude Code, Codex, Cursor, Gemini CLI, and other compatible agents:
+Install the [simple-modern-uv skill bundle](skills/simple-modern-uv/SKILL.md) with the
+[skills CLI](https://github.com/vercel-labs/skills), then appoint your coding agent to
+do the work. The bundle follows the [Agent Skills](https://agentskills.io) open format;
+the installer supports Claude Code, Codex, Cursor, Gemini CLI, and other compatible
+agents:
 
 ```shell
 NPM_CONFIG_IGNORE_SCRIPTS=true NPM_CONFIG_BEFORE=2026-07-31T18:59:05Z \
@@ -68,13 +69,11 @@ See the procedures for
 [template updates](skills/simple-modern-uv/references/update-templated-project.md).
 
 Generated projects are agent-ready too: each includes an
-[`AGENTS.md`](template/AGENTS.md.jinja) following the [agents.md](https://agents.md)
-standard (read natively by Codex, Cursor, Copilot, Gemini CLI, and others) with the
-project’s build/test commands and conventions, plus a [`CLAUDE.md`](template/CLAUDE.md)
-that imports it for Claude Code.
+[`AGENTS.md`](template/AGENTS.md.jinja) following the [AGENTS.md](https://agents.md)
+standard, with the project’s build, test, and development conventions, plus a
+[`CLAUDE.md`](template/CLAUDE.md) that imports it for Claude Code.
 
-For non-agent options, scroll down to
-[How to Use This Template](#how-to-use-this-template).
+To work without an agent, see [How to Use This Template](#how-to-use-this-template).
 
 ## Why a New Python Project Template?
 
@@ -146,9 +145,9 @@ discussed next.)
 One other benefit of this template is it uses
 [**copier**](https://github.com/copier-org/copier).
 
-Unlike with many previous project template tools, Copier allows you
-[pull future changes](#updating-your-project-template) to a template back into your
-instantiated copy any time.
+Unlike many previous project template tools, Copier lets you
+[pull future template changes](#updating-your-project-template) back into your
+instantiated copy at any time.
 
 You can start a project now, then if this template improves or is updated with other
 tools, you can pull those improvements back into your project, much like a git merge.
@@ -158,10 +157,10 @@ maintain it yourself.
 If you’re not familiar with Copier, take a moment to understand the
 [update feature](#updating-your-project-template).
 Then the options below will make sense.
-I put a few more thoughts on why a workflow like this is underrated is in
+I put a few more thoughts on why a workflow like this is underrated in
 [a Twitter thread](https://x.com/ojoshe/status/1896696860297019733).
 
-## What Tools are In This Template?
+## What Tools Are in This Template?
 
 simple-modern-uv uses the tools I’ve come to think are best for new projects:
 
@@ -328,13 +327,9 @@ Option 3 is handy if you prefer a GitHub template.
 
 ### Option 1: Use Your Agent (Recommended)
 
-Install the [agent skill](skills/simple-modern-uv/SKILL.md) and ask your agent; see
-[Use With Any Coding Agent](#use-with-any-coding-agent) above for the exact installation
-command and prompts.
-The skill covers four workflows: creating a **new project**, **selectively adopting**
-coherent feature bundles, **fully upgrading** an existing Python package (including
-migrations from Poetry, setuptools/pip, or PDM), and **updating** a project already
-managed by this template.
+Install the [agent skill](skills/simple-modern-uv/SKILL.md) and ask your agent.
+[Use with Any Coding Agent](#use-with-any-coding-agent) has the exact installation
+command, four workflow prompts, and adoption boundaries.
 The agent inspects the repo, confirms only material choices, performs the work
 non-interactively, and reports the resulting adoption level and validation.
 
@@ -396,19 +391,13 @@ Once you have the code, search for **`changeme`** for all field names like proje
 author, etc. You want to do this to the `.copier-answers.yml` file as well.
 You will also want to check the license/copyright.
 
-## Getting Started on Your Project
-
-Everything to get started is linked from the project **README.md**. It links to the
-**installation.md**, **development.md**, and **publishing.md**
-[starter docs](#starter-docs).
-
 ## Updating Your Project Template
 
 If you use Option 1 or Option 2 or if you pick Option 3 and correctly fill in your
 `.copier-answers.yml` file, you have the option to update your project with any future
 updates to this template at any time.
 
-If this file is updated with your project name etc., then you can
+When `.copier-answers.yml` records your project values, you can
 [update your project](https://copier.readthedocs.io/en/latest/updating/) to reflect any
 changes to this template by running `copier update`.
 
@@ -454,8 +443,9 @@ follows:
 
 - **Cooling-off period:** Don’t install or upgrade to a release less than 14 days old
   (most malicious publishes are caught within days).
-  For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this template sets it in generated `uv.toml`, CI, and the
+  uv supports a relative
+  [dependency cooldown](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns)
+  such as `"14 days"`; this template sets it in generated `uv.toml`, CI, and the
   Makefile. Standard workflows select that checked-in file explicitly so ambient user
   settings cannot make `uv.lock` nonportable.
 
@@ -473,6 +463,8 @@ See [updating.md](updating.md#supply-chain-hygiene) for how this template applie
 If you’re contributing to this template or forking it for your own use, see
 [**updating.md**](updating.md) for the full process to check for new versions, update
 the template, and verify changes in a downstream project.
+Maintainer research, frozen supply-chain evidence, and implementation records are
+indexed in the [project documentation](docs/project/README.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -458,13 +458,15 @@ follows:
 
 See [updating.md](updating.md#supply-chain-hygiene) for how this template applies these.
 
-## Maintaining This Template
+## Maintaining and Releasing This Template
 
 If you’re contributing to this template or forking it for your own use, see
 [**updating.md**](updating.md) for the full process to check for new versions, update
-the template, and verify changes in a downstream project.
-Maintainer research, frozen supply-chain evidence, and implementation records are
-indexed in the [project documentation](docs/project/README.md).
+the template, verify changes in a downstream project, and publish a GitHub Release.
+The GitHub Release creates the version tag only after the downstream gate passes; do not
+create a bare tag immediately after merging the template PR. Maintainer research, frozen
+supply-chain evidence, and implementation records are indexed in the
+[project documentation](docs/project/README.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,32 +17,55 @@ Appropriately enough, the comic is out of date.)
 be a good base for serious work but also simple so it’s an easy option for any small
 project, like an open source library or tool.
 It can also upgrade an existing project to a modern setup: uv, ruff, BasedPyright, and
-GitHub Actions. The [agent skill](#agent-quick-start) walks you through either workflow.
+GitHub Actions, or add only the practices that fit without forcing a full migration.
+The [agent skill](#use-with-any-coding-agent) handles each adoption path.
 
-## Agent Quick Start
+## Use With Any Coding Agent
 
-The fastest way to use this template is through your AI coding agent.
-Install the [skill](skills/simple-modern-uv/SKILL.md) (the
-[Agent Skills](https://agentskills.io) open standard, so it works with Claude Code,
-Codex, Cursor, Gemini CLI, and 50+ other agents):
+Install the [simple-modern-uv skill bundle](skills/simple-modern-uv/SKILL.md) and
+appoint your coding agent to do the work.
+It follows the [Agent Skills](https://agentskills.io) open standard, so it works with
+Claude Code, Codex, Cursor, Gemini CLI, and other compatible agents:
 
 ```shell
 NPM_CONFIG_IGNORE_SCRIPTS=true NPM_CONFIG_BEFORE=2026-07-31T18:59:05Z \
-  npx --yes skills@1.5.18 add jlevy/simple-modern-uv
+  npx --yes skills@1.5.18 add jlevy/simple-modern-uv \
+    --skill simple-modern-uv --yes
 ```
 
-Then tell your agent what you want, for example:
+Then describe the outcome rather than translating it into template commands:
 
-- “Start a new Python project called my-package using simple-modern-uv.”
-- “Upgrade this repo to follow simple-modern-uv best practices.”
-- “Update this project to the latest simple-modern-uv template.”
+| Goal | Example prompt | Result |
+| --- | --- | --- |
+| Start fresh | “Start a new Python project called `my-package` using simple-modern-uv.” | A complete, template-managed project |
+| Add features ad hoc | “Add simple-modern-uv’s uv lock policy and CI to this repo, but keep its build backend.” | Only the selected, compatible feature bundles |
+| Upgrade a project | “Migrate this package from Poetry to simple-modern-uv and preserve its public behavior.” | A full migration with future Copier updates |
+| Update later | “Update this project to the latest simple-modern-uv template.” | Upstream changes reconciled with local adaptations |
 
-No installer handy? Paste this into any agent instead:
+No installer handy? Tell the agent to fetch the
+[`SKILL.md`](skills/simple-modern-uv/SKILL.md) and the directly linked reference for the
+selected workflow from the same Git revision, then follow them.
 
-> Fetch
-> https://raw.githubusercontent.com/jlevy/simple-modern-uv/main/skills/simple-modern-uv/SKILL.md
-> and follow it to
-> [start a new Python project / upgrade this repo / update this project].
+### Adopt Only What Fits
+
+The skill treats conformance as a design choice, not a pass/fail label:
+
+- **Selective adoption** adds named capabilities without changing unrelated project
+  choices or claiming Copier ownership.
+- **Core toolchain adoption** adds uv, reproducible locking, linting, typing, tests, CI,
+  and agent guidance while preserving packaging or layout where appropriate.
+- **Full template-managed adoption** uses the rendered structure and
+  `.copier-answers.yml` so future `copier update` runs work.
+
+The agent first audits the repository, then reports what it will adopt unchanged, adapt
+to local constraints, preserve, or defer.
+Changes to supported Python versions, package layout, build backend, versioning,
+licensing, publishing, or CI remain explicit user decisions.
+See the procedures for
+[selective adoption](skills/simple-modern-uv/references/adopt-selectively.md),
+[full migration](skills/simple-modern-uv/references/adopt-existing.md),
+[new projects](skills/simple-modern-uv/references/start-new-project.md), and
+[template updates](skills/simple-modern-uv/references/update-templated-project.md).
 
 Generated projects are agent-ready too: each includes an
 [`AGENTS.md`](template/AGENTS.md.jinja) following the [agents.md](https://agents.md)
@@ -306,12 +329,14 @@ Option 3 is handy if you prefer a GitHub template.
 ### Option 1: Use Your Agent (Recommended)
 
 Install the [agent skill](skills/simple-modern-uv/SKILL.md) and ask your agent; see
-[Agent Quick Start](#agent-quick-start) above for the exact commands and prompts.
-The skill covers three workflows: creating a **new project**, **upgrading an existing
-Python package** to this template’s structure and tooling (including migrations from
-Poetry, setuptools/pip, or PDM), and **updating** a project already built from this
-template. Your agent collects the essentials (name, description, license, whether you
-publish to PyPI) and handles the rest non-interactively.
+[Use With Any Coding Agent](#use-with-any-coding-agent) above for the exact installation
+command and prompts.
+The skill covers four workflows: creating a **new project**, **selectively adopting**
+coherent feature bundles, **fully upgrading** an existing Python package (including
+migrations from Poetry, setuptools/pip, or PDM), and **updating** a project already
+managed by this template.
+The agent inspects the repo, confirms only material choices, performs the work
+non-interactively, and reports the resulting adoption level and validation.
 
 ### Option 2: Use `copier` and `git` Yourself
 

--- a/copier.yml
+++ b/copier.yml
@@ -11,7 +11,7 @@ _message_after_copy: |
     Remember to look for any unfilled `changeme` strings!
     The license and publishing setup follow your package_license and
     publish_to_pypi answers; change them later with, e.g.:
-    uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=Apache-2.0
+    uvx --exclude-newer "14 days" copier@9.17.0 update --data package_license=Apache-2.0
 
     Next steps:
 
@@ -21,7 +21,7 @@ _message_after_copy: |
     git commit -m "Initial commit from simple-modern-uv."
     # Sync after the first commit so dynamic versioning gives the editable
     # install a real version (not 0.0.0). This creates uv.lock; commit it so
-    # CI installs reproducibly with --frozen.
+    # CI installs reproducibly with --locked and verifies this file is current.
     make install
     git add uv.lock
     git commit -m "Add uv.lock."

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,30 @@
+# Project Documentation
+
+These documents support maintainers of the simple-modern-uv template.
+The public [README](../../README.md) owns project selection and usage;
+[updating.md](../../updating.md) owns the maintenance and release procedure.
+This index covers research, frozen release evidence, and implementation records.
+
+## Maintained Research
+
+- [uv changes](research/research-uv-changes.md): current uv timeline and template
+  recommendations; review during each dependency-update cycle
+- [Python type checkers](research/research-python-type-checkers.md): evidence behind the
+  template’s type-checker choice
+
+## Release Evidence
+
+- [v0.5.0 supply-chain manifest](research/research-v0.5.0-supply-chain-manifest.md):
+  frozen 2026-08-14 version, provenance, advisory, and validation record
+- [v0.4.0 supply-chain manifest](research/research-v0.4.0-supply-chain-manifest.md):
+  frozen evidence for the preceding release
+
+## Implementation Records
+
+- [Agent skill and template modernization](specs/active/plan-2026-06-11-agent-skill-and-modernization.md):
+  implemented in-repository design, with remaining activation and external retirement
+  work tracked in the document
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/research/research-uv-changes.md
+++ b/docs/project/research/research-uv-changes.md
@@ -1,6 +1,6 @@
 # Research: uv Changes Relevant to This Template
 
-**Last updated:** 2026-07-12
+**Last updated:** 2026-08-14
 
 **Author:** Joshua Levy (with agent assistance)
 
@@ -12,10 +12,11 @@ This template was created in March 2025, when uv was on 0.6.x. This living doc t
 uv’s evolution since then, focused on what matters to the template: defaults, build
 backends, publishing, supply-chain features, and anything that would change the
 template’s recommendations.
-At the v0.4.0 dependency freeze (2026-07-13T03:27:33Z), the latest uv was **0.11.28**.
-The template pins **0.11.25**, the newest version clearing the exact 14-day supply-chain
-cutoff. See the [release manifest](research-v0.4.0-supply-chain-manifest.md) for dates
-and provenance.
+At the v0.5.0 dependency freeze (2026-08-14T18:59:05Z), the latest uv was **0.12.4**.
+The template pins **0.12.0**, the newest version clearing the exact 14-day supply-chain
+cutoff. Version 0.12.1 missed the cutoff by 44 minutes, so it remains deferred with the
+newer patches. See the [release manifest](research-v0.5.0-supply-chain-manifest.md) for
+dates and provenance.
 
 ## Timeline of Notable Changes
 
@@ -39,15 +40,26 @@ and provenance.
   `uv workspace list/dir` stabilized.
   `uv venv` requires `--clear` to overwrite.
   `uv format` moved to Ruff 0.15 and the 2026 style.
-- **0.11.x (Mar 2026–now)**: TLS moved to OS-native verification (`--native-tls`
+- **0.11.x (Mar–Jul 2026)**: TLS moved to OS-native verification (`--native-tls`
   deprecated in favor of `--system-certs`). **`uv audit`** (preview; announced
   2026-06-08): scans `uv.lock` against the OSV database, with
   `--ignore`/`--ignore-until-fixed`. Opt-in **malware checks** on `uv add`/`uv sync` via
   `UV_MALWARE_CHECK=1` (0.11.16+). **`uv check`** (0.11.18, preview): runs Astral’s ty
   type checker. Python 3.15 betas are available in managed downloads; 3.15 final is
-  expected around October 2026. **0.11.25 hardens tar handling** against parser
-  differentials and rejects malformed or ambiguous source distributions that older uv
-  versions could accept.
+  expected around October 2026. **0.11.25 and 0.11.28 harden archive handling** against
+  parser differentials.
+  Versions 0.11.29–0.11.33 add JSON output to `uv tree`, improve frozen-sync and
+  `exclude-newer` performance, add `uv lock --refresh`, tighten path and credential
+  handling, and extend the preview audit/malware/type-checking commands.
+- **0.12.x (Jul 2026–now)**: existing projects keep their build backend, while newly
+  initialized packages use `uv_build`. The resolver now prefers stable releases and
+  falls back to prereleases only when necessary.
+  Hash directives, archive and wheel paths, `pylock.toml`, project paths, and publish
+  filenames receive stricter validation; MD5-only hash checking is rejected.
+  `uv run path/to/script.py` discovers the project relative to the script, and Python
+  upgrade/reinstall flags and dependency-group names are validated more consistently.
+  These changes do not require a template migration, but they strengthen its existing
+  locked build and publish paths.
 
 (Compiled from uv release notes and the Astral blog; re-verify details against the
 [changelog](https://github.com/astral-sh/uv/blob/main/CHANGELOG.md) when updating this
@@ -62,23 +74,30 @@ doc.)
    Revisit if uv grows native dynamic versioning.
    The build backends are exact-pinned and mirrored in a locked `build` dependency
    group; release builds use `--no-build-isolation` so `uv.lock` covers the build graph.
-2. **`[tool.uv] required-version = ">=0.9"`** (adopted): fails fast on uv versions that
-   predate relative-duration `UV_EXCLUDE_NEWER`. The same `[tool.uv]` table sets
-   `exclude-newer = "14 days"` so direct uv commands, not only Makefile and CI paths,
-   inherit the policy.
-3. **Watch `uv audit` and `UV_MALWARE_CHECK`**: `uv audit` is old enough to use as an
-   additional release-time check, but remains preview functionality in 0.11.25. Do not
+2. **Keep resolution policy in a checked-in `uv.toml`** (adopted):
+   `required-version = ">=0.9"` fails fast on versions that predate relative-duration
+   cutoffs, and `exclude-newer = "14 days"` supplies the safe default.
+   The Makefile and CI set `UV_CONFIG_FILE=uv.toml` so uv uses this file exclusively
+   instead of merging user- or system-level settings into `uv.lock`.
+3. **Watch `uv audit` and malware checking**: `uv audit` is old enough to use as an
+   additional release-time check, but remains preview functionality in 0.12.0. Do not
    make a preview command part of generated-project CI until it stabilizes.
-   Continue watching the opt-in malware check for the same reason.
+   Continue watching the opt-in malware-check settings for the same reason.
 4. **Keep `devtools/lint.py` over `uv format`/`uv check`** (decision).
    One command runs codespell, ruff check, ruff format, and basedpyright together, which
    neither uv command covers; `uv check` is also ty-based and preview (see the
    [type-checker research doc](research-python-type-checkers.md)).
 5. **Python 3.15**: add to the CI matrix and classifiers when final (~Oct 2026).
 6. **uv pin currency**: bump the pinned uv in `template/.github/workflows/*` at each
-   update cycle to the newest version clearing the 14-day cool-off (0.11.25 at the
-   v0.4.0 freeze). Update the setup-uv action and official platform checksum in the same
+   update cycle to the newest version clearing the 14-day cool-off (0.12.0 at the v0.5.0
+   freeze). Update the setup-uv action and official platform checksum in the same
    reviewed change.
+7. **Use `uv sync --locked` in CI and publishing** (adopted).
+   `--locked` installs from `uv.lock` and fails when `pyproject.toml` would change it.
+   `--frozen` skips that freshness check, so it can hide an uncommitted lockfile update
+   and is not the right verification contract for committed project metadata.
+   Selecting the project-owned `uv.toml` exclusively also makes the check portable
+   across machines with different user-level uv settings.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/docs/project/research/research-uv-changes.md
+++ b/docs/project/research/research-uv-changes.md
@@ -4,7 +4,8 @@
 
 **Author:** Joshua Levy (with agent assistance)
 
-**Status:** Maintained (review at each dependency-update cycle; see `updating.md`)
+**Status:** Maintained (review at each dependency-update cycle; see
+[updating.md](../../../updating.md))
 
 ## Overview
 
@@ -51,7 +52,7 @@ dates and provenance.
   Versions 0.11.29–0.11.33 add JSON output to `uv tree`, improve frozen-sync and
   `exclude-newer` performance, add `uv lock --refresh`, tighten path and credential
   handling, and extend the preview audit/malware/type-checking commands.
-- **0.12.x (Jul 2026–now)**: existing projects keep their build backend, while newly
+- **0.12.x (Jul 2026–present)**: existing projects keep their build backend, while newly
   initialized packages use `uv_build`. The resolver now prefers stable releases and
   falls back to prereleases only when necessary.
   Hash directives, archive and wheel paths, `pylock.toml`, project paths, and publish
@@ -61,9 +62,10 @@ dates and provenance.
   These changes do not require a template migration, but they strengthen its existing
   locked build and publish paths.
 
-(Compiled from uv release notes and the Astral blog; re-verify details against the
-[changelog](https://github.com/astral-sh/uv/blob/main/CHANGELOG.md) when updating this
-doc.)
+(Compiled from the official
+[uv changelog](https://github.com/astral-sh/uv/blob/main/CHANGELOG.md) and
+[Astral blog](https://astral.sh/blog/); re-verify both sources when updating this
+document.)
 
 ## Decisions and Action Items for the Template
 
@@ -78,7 +80,9 @@ doc.)
    `required-version = ">=0.9"` fails fast on versions that predate relative-duration
    cutoffs, and `exclude-newer = "14 days"` supplies the safe default.
    The Makefile and CI set `UV_CONFIG_FILE=uv.toml` so uv uses this file exclusively
-   instead of merging user- or system-level settings into `uv.lock`.
+   instead of merging user- or system-level settings into `uv.lock`, matching uv’s
+   documented
+   [configuration-file precedence](https://docs.astral.sh/uv/configuration/files/).
 3. **Watch `uv audit` and malware checking**: `uv audit` is old enough to use as an
    additional release-time check, but remains preview functionality in 0.12.0. Do not
    make a preview command part of generated-project CI until it stabilizes.

--- a/docs/project/research/research-uv-changes.md
+++ b/docs/project/research/research-uv-changes.md
@@ -35,8 +35,8 @@ dates and provenance.
   default. **`uv format` introduced** (preview; delegates to a pinned Ruff).
 - **0.9.x (Oct 2025–Feb 2026)**: default Python bumped to **3.14** (3.14.0 final, Oct
   2025); free-threaded 3.14+ usable without opt-in.
-  `UV_EXCLUDE_NEWER` accepts relative durations like `"14 days"` (the template’s CI
-  relies on this; hence `required-version = ">=0.9"`).
+  As of 0.9.17, `UV_EXCLUDE_NEWER` accepts relative durations like `"14 days"` (the
+  template’s CI relies on this).
 - **0.10.x (Feb–Mar 2026)**: `uv python upgrade`, `uv add --bounds`, and
   `uv workspace list/dir` stabilized.
   `uv venv` requires `--clear` to overwrite.
@@ -77,8 +77,11 @@ document.)
    The build backends are exact-pinned and mirrored in a locked `build` dependency
    group; release builds use `--no-build-isolation` so `uv.lock` covers the build graph.
 2. **Keep resolution policy in a checked-in `uv.toml`** (adopted):
-   `required-version = ">=0.9"` fails fast on versions that predate relative-duration
-   cutoffs, and `exclude-newer = "14 days"` supplies the safe default.
+   `required-version = ">=0.12.0,<0.13"` keeps local lockfile writes on the same
+   reviewed uv minor line as pinned CI, and `exclude-newer = "14 days"` supplies the
+   safe default. The lower bound includes relative-duration cutoff support (introduced in
+   0.9.17) and the security hardening reviewed for this release; the upper bound keeps a
+   later uv minor out until the template has assessed it.
    The Makefile and CI set `UV_CONFIG_FILE=uv.toml` so uv uses this file exclusively
    instead of merging user- or system-level settings into `uv.lock`, matching uv’s
    documented

--- a/docs/project/research/research-v0.5.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.5.0-supply-chain-manifest.md
@@ -24,7 +24,7 @@ packages by implication.
 
 ## Frozen Python and Tool Candidates
 
-| Component | Current declaration | Frozen decision | Published (UTC) | Source and rationale |
+| Component | Prior declaration | Frozen decision | Published (UTC) | Source and rationale |
 | --- | --- | --- | --- | --- |
 | uv | 0.11.25 | **Update to [0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0)** | 2026-07-28 | Newest eligible official Astral release; security and validation hardening with no generated-project migration |
 | Copier | 9.16.0 | **Update to [9.17.0](https://github.com/copier-org/copier/releases/tag/v9.17.0)** | 2026-07-13 | Fixes an encoded-URL trust bypass; fresh-copy and update-path tests are required |
@@ -86,8 +86,8 @@ against `astral-sh/uv`.
   The existing `skills-ref@0.1.5` integrity remains recorded in the v0.4.0 manifest.
 - `npm audit --omit=dev` reports five high-severity dependency families in setup-uv
   v9.0.0’s bundled production graph.
-  The same families are present in the currently pinned v8.2.0 and still appear in
-  v10.0.1; there is no eligible action release that removes them.
+  The same families are present in the prior v8.2.0 pin and still appear in v10.0.1;
+  there is no eligible action release that removes them.
   They concern glob, XML, and HTTP-library behaviors rather than a known setup-uv
   exploit. Full-SHA pinning, trusted workflow inputs, disabled publish caching, and
   continued upstream tracking bound the exposure without taking a same-day major release
@@ -143,8 +143,8 @@ Local validation produced these outcomes:
 7. A Copier 9.17.0 update from v0.4.0 has no rejects, converges with a fresh candidate
    render, and honors an explicit `publish_to_pypi=false` override.
 
-Every template-repository CI job remains the final pre-merge gate, including the full
-Python 3.11–3.14 matrix.
+Candidate acceptance requires every template-repository CI job, including the full
+Python 3.11–3.14 matrix, to pass before merge.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/docs/project/research/research-v0.5.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.5.0-supply-chain-manifest.md
@@ -1,0 +1,151 @@
+# Research: v0.5.0 Supply-Chain Manifest
+
+**Frozen:** 2026-08-14T18:59:05Z
+
+**Eligibility cutoff:** 2026-07-31T18:59:05Z (14 days)
+
+**Status:** Frozen for the v0.5.0 candidate
+
+## Scope and Decision Rule
+
+This manifest freezes a focused uv and pipeline currency update.
+Implementation does not chase releases published after the freeze.
+A version is eligible only when its first non-yanked artifact was published on or before
+the cutoff, its canonical source and intervening release notes are reviewable, and known
+advisories have been assessed.
+The candidate is numbered v0.5.0 because the portable lock policy adds `uv.toml` to the
+rendered project; no template question or application-facing package behavior changes.
+
+The audit covers template inputs, generated-project development and build dependencies,
+repository-only executable tools, active GitHub Actions, and their relevant source
+deltas. The generated project retains `exclude-newer = "14 days"` in a checked-in
+`uv.toml` and commits `uv.lock`; direct-package checks do not approve changed transitive
+packages by implication.
+
+## Frozen Python and Tool Candidates
+
+| Component | Current declaration | Frozen decision | Published (UTC) | Source and rationale |
+| --- | --- | --- | --- | --- |
+| uv | 0.11.25 | **Update to [0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0)** | 2026-07-28 | Newest eligible official Astral release; security and validation hardening with no generated-project migration |
+| Copier | 9.16.0 | **Update to [9.17.0](https://github.com/copier-org/copier/releases/tag/v9.17.0)** | 2026-07-13 | Fixes an encoded-URL trust bypass; fresh-copy and update-path tests are required |
+| Flowmark | 0.3.1 | **Update to [0.3.2](https://github.com/jlevy/flowmark-rs/releases/tag/v0.3.2)** | 2026-07-15 | Current eligible canonical release; formatter behavior is covered by `make format-check` |
+| pytest | >=9.1.1 | Keep >=9.1.1 | 2026-06-19 | Already latest |
+| pytest-sugar | >=1.1.1 | Keep >=1.1.1 | 2025-08-23 | Already latest |
+| Ruff | >=0.15.20 | **Raise to [>=0.16.1](https://github.com/astral-sh/ruff/releases/tag/0.16.1)** | 2026-07-30 | New default rules and Markdown formatting reviewed; explicit template rule selection isolates the lint default, with render linting as the compatibility gate |
+| codespell | >=2.4.2 | **Raise to [>=2.4.3](https://github.com/codespell-project/codespell/releases/tag/v2.4.3)** | 2026-07-15 | Packaging fix, new ignore controls, and dictionary maintenance |
+| Rich | >=15.0.0 | Keep >=15.0.0 | 2026-04-12 | Already latest |
+| basedpyright | >=1.39.9 | Keep >=1.39.9 | 2026-06-27 | 1.39.10 is after the cutoff |
+| funlog | >=0.2.1 | Keep >=0.2.1 | 2025-03-28 | Already latest |
+| Hatchling | 1.30.1 | **Pin [1.31.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.31.0)** | 2026-07-08 | Prevents non-Python shared scripts from being truncated during wheel construction |
+| uv-dynamic-versioning | 0.14.0 | Keep 0.14.0 | 2026-03-22 | Already latest; Hatchling remains necessary for tag-driven versions |
+| skills installer | 1.5.13 | **Update to [1.5.18](https://github.com/vercel-labs/skills/releases/tag/v1.5.18)** | 2026-07-16 | Includes unsafe-transport, shell-spawn, private-repository, and install-layout fixes while retaining Node >=18 support |
+| skills-ref | 0.1.5 | Keep 0.1.5 | 2025-12-27 | Already latest |
+| get-tbd | 0.2.3 bootstrap | Defer eligible 0.4.2 | 2026-07-30 | Repository-agent migration is separately tracked by `smu-i8xh` and is outside this focused template refresh |
+
+The newest eligible skills release is 1.5.21, but 1.5.19 raised its runtime floor from
+Node 18 to Node 22.20. Version 1.5.18 captures the preceding security and correctness
+fixes without narrowing the documented agent compatibility.
+Python remains 3.11 through 3.14; Python 3.15 is still prerelease.
+
+## Frozen GitHub Actions
+
+| Action | Frozen version | Full commit | Release state | Decision |
+| --- | --- | --- | --- | --- |
+| `actions/checkout` | [v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1) | `3d3c42e5aac5ba805825da76410c181273ba90b1` | Not immutable | Full-SHA pin protects the non-immutable tag; patch adds safer PR-input, branch-whitespace, and Git-config value handling |
+| `astral-sh/setup-uv` | [v9.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0) | `c771a70e6277c0a99b617c7a806ffedaca235ff9` | Immutable | Adopt the reviewed major release and make its cache-retention choice explicit |
+
+setup-uv v9 changes `prune-cache` from true to false.
+Generated CI explicitly keeps the new behavior because retaining downloaded wheels
+reduces repeated PyPI traffic.
+The privileged release workflow instead disables shared caching: its job is infrequent,
+and eliminating cache restore/save reduces cache-poisoning exposure.
+Repository jobs that do not benefit materially from a shared uv cache also disable it.
+
+setup-uv v9’s built-in checksum table ends before uv 0.12.0. Linux workflows therefore
+provide the official `uv-x86_64-unknown-linux-gnu` SHA-256 directly:
+`eaf842262aa1c418d8ecc5605f02ee1ebfd369124fa48548e85f9481a47831a9`. The downloaded
+release archive matched that checksum, and its GitHub artifact attestation verified
+against `astral-sh/uv`.
+
+## Provenance and Advisory Results
+
+- OSV queries returned no advisories for any selected direct Python or npm version.
+- The selected Copier and Hatchling distributions publish PyPI provenance.
+  uv and Ruff publish GitHub artifact attestations; both selected Linux archives passed
+  their official SHA-256 checks and `gh attestation verify`.
+- Reviewed PyPI source-distribution SHA-256 values include uv 0.12.0
+  (`80ba22cae467c6f47d2157ec2b840c032cac709b85ab1300ac4dcfeb29986462`), Copier 9.17.0
+  (`d966b043a15c74595f7904a6af89f3291135682f8313c4b71ef368811ed554f2`), Flowmark 0.3.2
+  (`d7d05b06ad2cef2b123cafe8b05e2545d29f474d455a26ab824fcdf0b5b557e2`), Ruff 0.16.1
+  (`fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7`), codespell 2.4.3
+  (`cbe085e331227b37bb86ef8bddd08dc768c704ee9a07ca869852c093fa2793e2`), and Hatchling
+  1.31.0 (`6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b`).
+- The reviewed npm registry integrity for `skills@1.5.18` is
+  `sha512-WwQuqIhmS2nrn1H3HAbE2tGe7e2npc1cwMcucMKqmkBdqzm7nxzcZBTqXiHjUKhpalQLE/nNPtEdcx3QYX4TTw==`;
+  npm provenance is present.
+  The existing `skills-ref@0.1.5` integrity remains recorded in the v0.4.0 manifest.
+- `npm audit --omit=dev` reports five high-severity dependency families in setup-uv
+  v9.0.0’s bundled production graph.
+  The same families are present in the currently pinned v8.2.0 and still appear in
+  v10.0.1; there is no eligible action release that removes them.
+  They concern glob, XML, and HTTP-library behaviors rather than a known setup-uv
+  exploit. Full-SHA pinning, trusted workflow inputs, disabled publish caching, and
+  continued upstream tracking bound the exposure without taking a same-day major release
+  exception.
+
+## Explicit Deferrals
+
+The following releases were younger than the cutoff and are excluded without exception:
+
+- uv 0.12.1 through 0.12.4; 0.12.1 missed the cutoff by about 44 minutes
+- Copier 9.17.1, Ruff 0.16.2 and 0.16.3, basedpyright 1.39.10, and Hatchling 1.32.0
+- setup-uv v10.0.0 and v10.0.1
+
+No preview uv command becomes a generated CI dependency.
+`uv audit`, `uv check`, and `uv format` continue as release-time or watch-list
+capabilities. The project keeps Hatchling rather than moving to `uv_build`, because its
+tag-derived dynamic versioning is part of the template’s release model.
+
+## Pipeline Decisions and Validation Gates
+
+Generated CI and publishing change from `uv sync --frozen` to `uv sync --locked`.
+`--locked` still installs from the committed lock but also fails when project metadata
+would make that lock stale; `--frozen` intentionally skips this validation.
+
+uv merges project-, user-, and system-level configuration by default, including mapping
+settings such as `exclude-newer-package`, and records resolution settings in `uv.lock`.
+A lock created with this machine’s intentional first-party exceptions therefore failed
+`--locked` on a clean runner even though the dependency metadata was current.
+The template moves its uv settings to `uv.toml`; the Makefile and workflows select that
+file with `UV_CONFIG_FILE`, which official uv semantics define as exclusive of
+discovered user and system configuration.
+Project-specific indexes and resolution settings remain supported by checking them into
+`uv.toml`.
+
+Local validation produced these outcomes:
+
+1. The v0.4.0 and candidate locks each contain 25 packages.
+   Hatchling 1.30.1 to 1.31.0 is the only resolved-version change; the Ruff and
+   codespell floor changes already matched the versions selected by the frozen v0.4.0
+   graph.
+2. `uv audit --locked` reports no known vulnerabilities or adverse project statuses in
+   the 24 third-party packages.
+3. Fresh default, no-publish/proprietary, and no-license renders have the expected file,
+   license, classifier, and workflow shapes.
+4. The Python 3.12 default render installs, passes codespell/Ruff/BasedPyright and
+   pytest, and builds its sdist and wheel through the locked non-isolated Hatchling
+   path.
+5. `uv sync --locked` rejects an intentionally stale `pyproject.toml` with the expected
+   lockfile-update error.
+6. A lock produced with an explicitly selected `uv.toml` passes `--locked` under both
+   this machine’s user configuration and an empty user configuration; neither ambient
+   configuration appears in the lock.
+7. A Copier 9.17.0 update from v0.4.0 has no rejects, converges with a fresh candidate
+   render, and honors an explicit `publish_to_pypi=false` override.
+
+Every template-repository CI job remains the final pre-merge gate, including the full
+Python 3.11–3.14 matrix.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/research/research-v0.5.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.5.0-supply-chain-manifest.md
@@ -31,7 +31,7 @@ packages by implication.
 | Flowmark | 0.3.1 | **Update to [0.3.2](https://github.com/jlevy/flowmark-rs/releases/tag/v0.3.2)** | 2026-07-15 | Current eligible canonical release; formatter behavior is covered by `make format-check` |
 | pytest | >=9.1.1 | Keep >=9.1.1 | 2026-06-19 | Already latest |
 | pytest-sugar | >=1.1.1 | Keep >=1.1.1 | 2025-08-23 | Already latest |
-| Ruff | >=0.15.20 | **Raise to [>=0.16.1](https://github.com/astral-sh/ruff/releases/tag/0.16.1)** | 2026-07-30 | New default rules and Markdown formatting reviewed; explicit template rule selection isolates the lint default, with render linting as the compatibility gate |
+| Ruff | >=0.15.20 | **Raise to [>=0.16.1](https://github.com/astral-sh/ruff/releases/tag/0.16.1)** | 2026-07-30 | Markdown formatting is a new default; exclude `*.md` so Flowmark retains ownership, with a rendered regression fixture as the compatibility gate |
 | codespell | >=2.4.2 | **Raise to [>=2.4.3](https://github.com/codespell-project/codespell/releases/tag/v2.4.3)** | 2026-07-15 | Packaging fix, new ignore controls, and dictionary maintenance |
 | Rich | >=15.0.0 | Keep >=15.0.0 | 2026-04-12 | Already latest |
 | basedpyright | >=1.39.9 | Keep >=1.39.9 | 2026-06-27 | 1.39.10 is after the cutoff |
@@ -134,7 +134,8 @@ Local validation produced these outcomes:
    license, classifier, and workflow shapes.
 4. The Python 3.12 default render installs, passes codespell/Ruff/BasedPyright and
    pytest, and builds its sdist and wheel through the locked non-isolated Hatchling
-   path.
+   path. An intentionally unformatted Python fence under `tests/` verifies that Ruff
+   leaves Markdown to Flowmark.
 5. `uv sync --locked` rejects an intentionally stale `pyproject.toml` with the expected
    lockfile-update error.
 6. A lock produced with an explicitly selected `uv.toml` passes `--locked` under both

--- a/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
+++ b/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
@@ -13,10 +13,10 @@ Make simple-modern-uv directly usable by AI coding agents.
 The centerpiece is a single installable **agent skill** that any of the standard skill
 channels can deliver into any agent environment, letting a user say one sentence
 ("upgrade this repo to modern uv best practices") and have the agent do the rest: create
-a new project from the template, convert an existing Python package to follow the
-template, or pull the latest template updates into an already-templated project —
-including customizations like changing the license or making the package private and
-unpublished.
+a new project from the template, add selected practices to an existing repository,
+convert an existing Python package to follow the full template, or pull the latest
+template updates into an already-templated project — including customizations like
+changing the license or making the package private and unpublished.
 
 Alongside the skill, modernize the template itself: re-introduce agent instructions
 (`AGENTS.md`, now a stable cross-agent standard), add first-class template options for
@@ -31,9 +31,9 @@ A summary of uv’s evolution since this template was created (March 2025) is in
 - **One-paste install**: a user can paste a single command or prompt into any agent
   environment (Claude Code, Codex, Cursor, Gemini CLI, …) and get a working
   simple-modern-uv skill.
-- **Three workflows in one skill**: new project, adopt an existing (non-template) Python
-  package, and update an already-templated project — all fully non-interactive, driven
-  by the agent.
+- **Four workflows in one skill**: new project, selective feature adoption, full
+  migration of an existing Python package, and update of an already-templated project —
+  all driven by the agent.
 - **First-class customization**: license selection and published/private packaging are
   template options (not post-render hand edits), so `copier update` stays coherent.
 - **Validated template**: this repo gets CI that renders the template and runs the full
@@ -88,15 +88,17 @@ tooling.
 
 ## User Flows
 
-First principles: every flow collects the **same answer set** — the questions in
-`copier.yml` (name, module, description, author, email, GitHub org, plus the new D2
-license and publish options).
-That question set is the single shared schema ("the interview"). The three flows differ
-only in **where the answers come from**, and every flow follows the same shape: **infer
-→ confirm once → execute → verify → next steps**.
+The current model has four flows: start new, adopt selected features, migrate fully, and
+update a template-managed project.
+New projects and full migrations collect the template answer set from `copier.yml`.
+Selective adoption asks only about material decisions created by the selected features,
+and template updates reuse recorded answers while reconciling new questions with
+observed project state.
+Every flow follows the same shape: **inspect and infer → confirm material choices once →
+execute → verify → report adoption**.
 
-The interview contract (specified in `SKILL.md`, binding on all flows) — the questions
-have two tiers:
+The interview contract (specified in `SKILL.md`, used whenever template answers are
+needed) has two tiers:
 
 **Essentials** — the confirmation round centers on these, and they are the only things
 the user is expected to decide:
@@ -111,48 +113,62 @@ the user is expected to decide:
 - **License** (default MIT) and **publish to PyPI?** (default yes) — always surfaced
   with their defaults named, since these are the decisions with real consequences.
 
-**Conventions** — everything else is a minor variation the agent applies silently and
-mentions in the post-run summary, deviating only when the user states an explicit need:
-`src/` layout (always), initial version `v0.1.0` tag for a new project (for an upgrade,
-the next sensible version above what’s on PyPI), Python 3.11+ floor, line length, tool
-choices. These are never questions.
+**Conventions** — for a new project or full migration, everything else is a minor
+variation the agent applies and mentions in the post-run summary, deviating when the
+user states an explicit need: `src/` layout, initial version `v0.1.0` tag for a new
+project (for an upgrade, the next sensible version above what’s on PyPI), Python 3.11+
+floor, line length, and tool choices.
+Selective adoption instead preserves existing choices unless the requested feature
+requires a change.
 
 Mechanics of the contract:
 
 - **Infer before asking.** Author name/email from `git config`; GitHub org from the repo
   remote or `gh` auth; package name from the user’s request or the directory; for
-  existing projects, nearly everything from the repo itself (see Flow 2). Inferred
-  values appear in the confirmation summary, not as questions.
+  existing projects, nearly everything from the repo itself.
+  Inferred values appear in the confirmation summary, not as questions.
 - **Ask once, batched.** Whatever can’t be inferred is asked in a single round alongside
   the confirmation summary — never a question-per-answer interrogation (that’s the
   interactive-prompt experience the agent replaces).
-- **Execute non-interactively** via pinned `uvx copier … --defaults --data k=v`.
-- **Verify before declaring done**: `uv sync --all-extras`, `make lint`, `make test`
-  (and `uv build` when publishing) must pass.
+- **Execute non-interactively** via pinned `uvx copier … --defaults --data k=v` when a
+  render or update is part of the selected workflow.
+- **Verify before declaring done**: full and core adoption run `make install`,
+  `make lint`, and `make test` (plus `make build` when publishing); selective adoption
+  runs the smallest checks that prove each touched feature.
 - **End with next steps**, not a dead stop: README fill-in, repo creation/push, Trusted
   Publishing setup (if publishing), how to update later.
+
+### Flow 0: Adopt selected features ("add only what fits")
+
+The user names a capability and a boundary, for example: *“Add simple-modern-uv’s uv
+lock policy and CI, but keep this package’s build backend.”* The agent audits the
+repository, maps relevant bundles to adopt/adapt/preserve/defer, and asks only about
+material conflicts created by those features.
+It may render the template beside the project as a reference, but it makes the smallest
+coherent change, preserves equivalent existing tools, and never adds
+`.copier-answers.yml`. The handoff explicitly says the project is selectively or
+core-toolchain aligned rather than template-managed.
 
 ### Flow 1: New project ("set me up from scratch")
 
 The user pastes one thing into any agent (both variants in the README):
 
 ```
-npx skills add jlevy/simple-modern-uv
+npx --yes skills@1.5.18 add jlevy/simple-modern-uv --skill simple-modern-uv --yes
 ```
 
 > Use the simple-modern-uv skill to start a new Python project called acme-widgets.
 
-(or, zero-install: *“Fetch
-https://raw.githubusercontent.com/jlevy/simple-modern-uv/main/skills/simple-modern-uv/SKILL.md
-and follow it to start a new Python project called acme-widgets.”*)
+(or, zero-install: *“Fetch the simple-modern-uv `SKILL.md` and its new-project reference
+from the same Git revision, then follow them to start a project called acme-widgets.”*)
 
 The agent then: infers author/email/org from the environment, asks the single batched
 round covering the essentials only (name normalization shown; description; license —
 default MIT; publish to PyPI? — default yes; org if not inferred), renders with
-`--data`, runs `git init` + `uv sync --all-extras` + first commit, verifies lint/tests
-pass, and offers the optional finish (create the GitHub repo and push; tag `v0.1.0` when
-ready to release; if publishing, point at `docs/publishing.md` for the one-time Trusted
-Publisher setup). Layout and initial version are conventions, not questions.
+`--data`, creates the initial commit, runs `make install`, verifies lint/tests pass, and
+offers the optional finish (create the GitHub repo and push; tag `v0.1.0` when ready to
+release; if publishing, point at `docs/publishing.md` for the one-time Trusted Publisher
+setup). Layout and initial version are conventions, not questions.
 
 ### Flow 2: Upgrade an existing project ("modernize this repo")
 
@@ -204,15 +220,20 @@ A single skill folder, committed at the repo root in the universal discovery loc
 ```
 skills/
 └── simple-modern-uv/
-    ├── SKILL.md              # routing layer: the interview contract + the three flows
+    ├── SKILL.md              # routing, adoption levels, and shared contract
     └── references/
-        ├── adopt-existing.md # checklist: convert an existing package to the template
-        ├── customize.md      # license, private/unpublished, other post-render tweaks
-        └── faq.md            # common problems across flows, mostly migrations
+        ├── start-new-project.md
+        ├── adopt-selectively.md
+        ├── adopt-existing.md
+        ├── update-templated-project.md
+        ├── customize.md
+        └── faq.md
 ```
 
-`SKILL.md` carries the interview contract and routes the three User Flows; the
-references carry the bulk.
+`SKILL.md` is the orientation map: it chooses the workflow, defines selective, core, and
+full template-managed adoption, and carries the shared interview, safety, verification,
+and handoff contracts.
+One-level references own each procedure.
 `references/faq.md` is the troubleshooting layer the upgrade flow leans on; at minimum
 it covers: dynamic version resolving to `0.0.0` (no git tag yet; first tag must exceed
 any published PyPI version), flat→`src/` layout moves (and how to stay flat if
@@ -226,34 +247,32 @@ reports.
 Design rules (per `tbd guidelines cli-agent-skill-patterns`):
 
 - **Frontmatter**: standard fields only (`name`, `description`, `license`,
-  `compatibility`, `metadata`) plus `allowed-tools` for portability across agents.
+  `compatibility`, `metadata`). Omit experimental `allowed-tools`: it is not portable,
+  and pre-approving a general package runner such as `uvx` would grant more execution
+  authority than this skill needs.
   `name: simple-modern-uv` (must match the directory name).
   The `description` follows the two-part rule — what it does plus explicit triggers
-  ("Use when creating a new Python project, modernizing or migrating an existing Python
-  package to uv, converting from Poetry/setuptools/pip, or updating a project built from
+  ("Use when creating a Python project, selectively adding repository practices,
+  migrating from Poetry/setuptools/pip/PDM/hatch, or updating a project managed by
   simple-modern-uv").
-- **Route, don’t restate**: the skill names each workflow and the exact command that
-  reaches it. `copier.yml` remains the single source of truth for template questions; the
-  skill points at `uvx copier@<pinned> copy --help` and the template’s own docs rather
-  than transcribing them.
+- **Route, don’t restate**: the skill names and directly links each workflow; the
+  selected one-level reference owns its exact commands and checklist.
+  `copier.yml` remains the single source of truth for template questions.
   Body stays well under 500 lines; bulky checklists live in `references/`, one level
   deep.
 - **Pinned invocations**: every command in the skill pins versions
   (`uvx copier@<X.Y.Z> copy gh:jlevy/simple-modern-uv …`), per the supply-chain rule
   that unpinned `uvx`/`npx` re-resolves to latest and bypasses any cool-off window.
-- **Self-contained when fetched raw**: the skill works when installed as a folder
-  (relative `references/` links) and also names the raw GitHub URLs, so a user can
-  bootstrap by pasting a prompt that points at the raw `SKILL.md` with no installer at
-  all.
+- **Complete bundle at one ref**: normal installation materializes `SKILL.md` and every
+  reference together. A zero-install prompt tells the agent to fetch the selected
+  one-level reference from the same Git revision, preventing mixed procedure versions.
 
-The skill body routes the three User Flows above — new project (Flow 1, pinned
-`copier copy` plus the git/verify steps), upgrade an existing package (Flow 2, the
-render-and-merge procedure in `references/adopt-existing.md`, whose checklist enumerates
-the per-source translations: Poetry dep specs → PEP 621, `tool.poetry.scripts` →
-`project.scripts`, dev deps → `dependency-groups`, etc.), and update a templated project
-(Flow 3, `copier update`). Customization (license change, private/no-publish,
-app-vs-library) is reachable from all three flows via `references/customize.md` plus the
-D2 template options.
+The skill routes new-project rendering, selective adoption of coherent feature bundles,
+full render-and-merge migration, and `copier update`. The selective flow never creates
+`.copier-answers.yml`; only a deliberate fresh render or full migration establishes
+Copier lineage. Customization (license change, private/no-publish, app-vs-library) is
+reachable from every relevant flow via `references/customize.md` plus the D2 template
+options.
 
 ### D2. Template options for license and publishing
 
@@ -311,19 +330,18 @@ standardization (see Background).
 
 ### D4. Remove `uvtemplate` entirely
 
-The three flows fully subsume what `uvtemplate` did (its value was the guided interview,
-and the interview contract moves that into the agent), so it is removed rather than
-demoted — all tooling consolidates in this repo, and no second wrapper CLI remains to
-maintain.
+The agent workflows fully subsume what `uvtemplate` did (its value was the guided
+interview, and the interview contract moves that into the agent), so it is removed
+rather than demoted — all tooling consolidates in this repo, and no second wrapper CLI
+remains to maintain.
 
 In this repo, every `uvtemplate` reference goes away: the PyPI badge in the README
 header, the “In a Hurry?”
 section, the old “Option 1: Run `uvx uvtemplate`”, and the cross-references in
 `template/docs/publishing.md`. The README’s “How to Use This Template” becomes:
 
-- **Option 1: use your agent.** Copy-paste blocks per flow (see User Flows): the
-  `npx skills add jlevy/simple-modern-uv` install line plus a one-line prompt for new /
-  upgrade / update, and the zero-install raw-`SKILL.md` prompt variant.
+- **Option 1: use your agent.** The README routes new, selective, full-migration, and
+  update requests through the installed skill, with a zero-install bundle-fetch variant.
 - **Option 2: copier by hand** (unchanged, for humans who want the terminal — this was
   always what `uvtemplate` wrapped).
 - **Option 3: GitHub template repo** (unchanged).
@@ -369,7 +387,10 @@ self-validating. `updating.md` is updated to reflect the new split.
 
 **2026-08-14 follow-up:** the next focused currency cycle advances the eligible uv pin
 to 0.12.0, reviews the 0.12 compatibility changes, updates the supporting tool and
-action pins, and strengthens portable CI lockfile validation.
+action pins, strengthens portable CI lockfile validation, and makes selective adoption a
+first-class fourth agent workflow.
+Generated `AGENTS.md` now routes template maintenance back to the portable skill while
+keeping routine project work self-contained.
 See the
 [v0.5.0 supply-chain manifest](../../research/research-v0.5.0-supply-chain-manifest.md)
 and the maintained [uv changes research](../../research/research-uv-changes.md).
@@ -388,8 +409,10 @@ defaults. No checker switch.
 
 ### Phase 1: The skill and its docs
 
-- [x] Write `skills/simple-modern-uv/SKILL.md` (frontmatter per D1; the interview
-  contract; routes the three User Flows; route-don’t-restate)
+- [x] Write `skills/simple-modern-uv/SKILL.md` (frontmatter per D1; adoption levels,
+  shared contracts, and routing for all four flows)
+- [x] Add one-level procedure references for new projects, selective adoption, full
+  migration, and template updates
 - [x] Write `references/adopt-existing.md` (render-and-merge checklist with per-source
   translations: setuptools/pip, Poetry, PDM/hatch; the Flow 2 migration decision points;
   verification gate)
@@ -439,8 +462,8 @@ defaults. No checker switch.
   vanilla no-op asserted.
 - **Skill validation**: `npx skills-ref validate` in CI; link/reference resolution
   check.
-- **Skill behavior**: manual end-to-end runs of all three User Flows with a real agent
-  (new project; adopt a small Poetry project; `copier update` on the downstream repo),
+- **Skill behavior**: manual end-to-end runs of all four User Flows with a real agent
+  (new project; selective feature adoption; full Poetry migration; `copier update`),
   checking the interview contract holds (inference correct, one batched question round,
   decision points surfaced, verification gate run), plus activation testing
   (should-trigger and should-not-trigger prompts).
@@ -453,9 +476,10 @@ defaults. No checker switch.
    merged — `npx skills add` tracks the repo).
 2. Run the `updating.md` release flow: export to the downstream repo, wait for CI, then
    tag a release.
-3. After the release: verify `npx skills add jlevy/simple-modern-uv` end-to-end from a
-   clean environment, then retire uvtemplate (deprecation note, final pointer release,
-   archive — D4).
+3. After the release: verify
+   `npx skills add jlevy/simple-modern-uv --skill simple-modern-uv --yes` end-to-end
+   from a clean environment, then retire uvtemplate (deprecation note, final pointer
+   release, archive — D4).
 4. Optional later: submit to the Anthropic community plugin marketplace
    (`clau.de/plugin-directory-submission`) for reviewed, security-screened
    discoverability inside Claude Code.

--- a/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
+++ b/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
@@ -394,7 +394,8 @@ The initial 2026-06-11 currency plan was:
 
 **2026-08-14 follow-up:** the next focused currency cycle advances the eligible uv pin
 to 0.12.0, reviews the 0.12 compatibility changes, updates the supporting tool and
-action pins, strengthens portable CI lockfile validation, and makes selective adoption a
+action pins, aligns the generated `required-version` guard with the reviewed 0.12 minor
+line, strengthens portable CI lockfile validation, and makes selective adoption a
 first-class fourth agent workflow.
 Generated `AGENTS.md` now routes template maintenance back to the portable skill while
 keeping routine project work self-contained.

--- a/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
+++ b/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
@@ -4,42 +4,47 @@
 
 **Author:** Joshua Levy (with agent assistance)
 
-**Status:** Implemented (in-repo work; activation testing and the external uvtemplate
-retirement remain — see Implementation Plan)
+**Status:** Implemented in this repository.
+This dated design record preserves the decisions and rollout state; activation testing
+and the external uvtemplate retirement remain (see
+[Implementation Plan](#implementation-plan)). Current operating guidance lives in the
+[README](../../../../README.md), the
+[simple-modern-uv skill](../../../../skills/simple-modern-uv/SKILL.md), and the
+maintained [uv changes research](../../research/research-uv-changes.md).
 
 ## Overview
 
 Make simple-modern-uv directly usable by AI coding agents.
-The centerpiece is a single installable **agent skill** that any of the standard skill
-channels can deliver into any agent environment, letting a user say one sentence
-("upgrade this repo to modern uv best practices") and have the agent do the rest: create
-a new project from the template, add selected practices to an existing repository,
-convert an existing Python package to follow the full template, or pull the latest
-template updates into an already-templated project — including customizations like
-changing the license or making the package private and unpublished.
+The centerpiece is a single installable **agent skill** that compatible skill channels
+can deliver into supported agent environments, letting a user say one sentence ("upgrade
+this repo to modern uv best practices") and have the agent do the rest: create a new
+project from the template, add selected practices to an existing repository, convert an
+existing Python package to follow the full template, or pull the latest template updates
+into an already-templated project—including customizations like changing the license or
+making the package private and unpublished.
 
 Alongside the skill, modernize the template itself: re-introduce agent instructions
 (`AGENTS.md`, now a stable cross-agent standard), add first-class template options for
 the two customizations agents most need (license and publish-to-PyPI), remove the
 interactive `uvtemplate` tool (the skill’s flows fully subsume it), add CI to this repo
 so template changes are validated on every PR, and refresh tool versions.
-A summary of uv’s evolution since this template was created (March 2025) is in
-[Appendix A](#appendix-a-uv-changes-since-march-2025) with the resulting action items.
+The maintained [uv changes research](../../research/research-uv-changes.md) owns uv’s
+version timeline and the resulting recommendations.
 
 ## Goals
 
-- **One-paste install**: a user can paste a single command or prompt into any agent
-  environment (Claude Code, Codex, Cursor, Gemini CLI, …) and get a working
-  simple-modern-uv skill.
+- **One-paste install**: a user can paste a single command or prompt into a compatible
+  agent environment (Claude Code, Codex, Cursor, Gemini CLI, and others) and get a
+  working simple-modern-uv skill.
 - **Four workflows in one skill**: new project, selective feature adoption, full
-  migration of an existing Python package, and update of an already-templated project —
+  migration of an existing Python package, and update of an already-templated project—
   all driven by the agent.
 - **First-class customization**: license selection and published/private packaging are
   template options (not post-render hand edits), so `copier update` stays coherent.
-- **Validated template**: this repo gets CI that renders the template and runs the full
+- **Validated template**: this repo has CI that renders the template and runs the full
   lint/test/build cycle, plus skill validation, on every PR.
-- **Currency**: uv pin, dependency floors, and the basedpyright research doc are
-  refreshed; uv changes since the template’s creation are summarized with action items.
+- **Currency**: uv pin, dependency floors, and the BasedPyright research are refreshed;
+  the maintained uv research records version-specific recommendations.
 
 ## Non-Goals
 
@@ -48,11 +53,11 @@ A summary of uv’s evolution since this template was created (March 2025) is in
   (`copier copy --defaults --data k=v`, verified against this template); a wrapper CLI
   would duplicate it.
 - No self-installing machinery (no managed `AGENTS.md` blocks, no hooks, no format
-  versioning). The skill is a plain folder of Markdown — “L1” on the integration ladder
-  in `tbd guidelines cli-agent-skill-patterns`.
+  versioning). The skill is a plain folder of Markdown—“L1” on the integration ladder in
+  `tbd guidelines cli-agent-skill-patterns`.
 - No expansion of template scope (still no Docker, docs sites, monorepos, or non-GitHub
   CI).
-- Migration tooling for exotic legacy setups (conda, setup.py with C extensions) — the
+- Migration tooling for exotic legacy setups (conda, setup.py with C extensions)—the
   adopt workflow targets the common cases (setuptools/pip, Poetry, PDM, hatch).
 
 ## Background
@@ -65,55 +70,54 @@ Three things changed since this template was built (March 2025):
    Copier itself provides those (`--defaults`, `--data`, `--vcs-ref`), so the
    interactive wrapper is no longer the right front door.
 
-2. **Skills and AGENTS.md became open standards.** Agent Skills (`SKILL.md`) is an open
-   standard (agentskills.io, created by Anthropic, implemented by 20+ agents), and
-   `AGENTS.md` is stewarded by the Linux Foundation’s Agentic AI Foundation and read
-   natively by Codex, Cursor, Copilot, Gemini CLI, and others.
+2. **Agent Skills and AGENTS.md provide portable conventions.**
+   [Agent Skills](https://agentskills.io) defines an open `SKILL.md` format for
+   compatible clients, and [AGENTS.md](https://agents.md) is stewarded by the Linux
+   Foundation’s Agentic AI Foundation and supported across coding agents.
    This template removed its agent rules in early 2025 because the formats were
    churning; that reason no longer holds.
-   Distribution also standardized: `npx skills add owner/repo` (Vercel’s skills.sh, the
-   de facto cross-agent installer) installs any `skills/<name>/SKILL.md` from a public
-   GitHub repo into 50+ agents, and GitHub-scraping indexers list such repos
-   automatically.
+   The [skills CLI](https://github.com/vercel-labs/skills) installs a
+   `skills/<name>/SKILL.md` bundle from a Git repository into supported agent layouts.
 
 3. **The template’s own guidance is now upstream knowledge.** tbd’s
    `python-modern-guidelines` cites simple-modern-uv as the reference model for Python
    releasing. The skill closes the loop: the template becomes directly executable
-   knowledge for any agent, not just prose.
+   knowledge for compatible agents, not just prose.
 
-A verification note: rendering this template fully non-interactively was tested locally
-(`uvx copier@9.15.1 copy --defaults --data package_name=… --data …`) and produces a
-complete project including the derived `package_module`. The agent path needs no new
-tooling.
+Initial design validation rendered the template fully non-interactively with Copier
+9.15.1 and produced a complete project, including the derived `package_module`. The
+implemented workflow uses the reviewed Copier version documented in the skill.
 
 ## User Flows
 
-The current model has four flows: start new, adopt selected features, migrate fully, and
-update a template-managed project.
-New projects and full migrations collect the template answer set from `copier.yml`.
+The implemented model has four flows: start new, adopt selected features, migrate fully,
+and update a template-managed project.
+New projects and full migrations collect the template answer set from
+[`copier.yml`](../../../../copier.yml).
 Selective adoption asks only about material decisions created by the selected features,
 and template updates reuse recorded answers while reconciling new questions with
 observed project state.
 Every flow follows the same shape: **inspect and infer → confirm material choices once →
 execute → verify → report adoption**.
 
-The interview contract (specified in `SKILL.md`, used whenever template answers are
-needed) has two tiers:
+The interview contract (specified in
+[SKILL.md](../../../../skills/simple-modern-uv/SKILL.md), used whenever template answers
+are needed) has two tiers:
 
-**Essentials** — the confirmation round centers on these, and they are the only things
+**Essentials:** The confirmation round centers on these, and they are the only things
 the user is expected to decide:
 
 - **Package name** (which is also the PyPI name and, by default, the repo name) in
-  **kebab-case**, and the **module name** in **snake_case** — the agent normalizes
+  **kebab-case**, and the **module name** in **snake_case**—the agent normalizes
   whatever the user said ("Acme Widgets" → package `acme-widgets`, module
   `acme_widgets`) and shows the mapping; `copier.yml` already validates the module name,
   and the skill enforces the kebab/snake conventions rather than asking the user to know
   them.
 - **Description** (one line).
-- **License** (default MIT) and **publish to PyPI?** (default yes) — always surfaced
-  with their defaults named, since these are the decisions with real consequences.
+- **License** (default MIT) and **publish to PyPI?** (default yes)—always surfaced with
+  their defaults named, since these are the decisions with real consequences.
 
-**Conventions** — for a new project or full migration, everything else is a minor
+**Conventions:** For a new project or full migration, everything else is a minor
 variation the agent applies and mentions in the post-run summary, deviating when the
 user states an explicit need: `src/` layout, initial version `v0.1.0` tag for a new
 project (for an upgrade, the next sensible version above what’s on PyPI), Python 3.11+
@@ -128,7 +132,7 @@ Mechanics of the contract:
   existing projects, nearly everything from the repo itself.
   Inferred values appear in the confirmation summary, not as questions.
 - **Ask once, batched.** Whatever can’t be inferred is asked in a single round alongside
-  the confirmation summary — never a question-per-answer interrogation (that’s the
+  the confirmation summary—never a question-per-answer interrogation (that’s the
   interactive-prompt experience the agent replaces).
 - **Execute non-interactively** via pinned `uvx copier … --defaults --data k=v` when a
   render or update is part of the selected workflow.
@@ -138,7 +142,7 @@ Mechanics of the contract:
 - **End with next steps**, not a dead stop: README fill-in, repo creation/push, Trusted
   Publishing setup (if publishing), how to update later.
 
-### Flow 0: Adopt selected features ("add only what fits")
+### Flow 0: Adopt Selected Features ("Add Only What Fits")
 
 The user names a capability and a boundary, for example: *“Add simple-modern-uv’s uv
 lock policy and CI, but keep this package’s build backend.”* The agent audits the
@@ -149,9 +153,9 @@ coherent change, preserves equivalent existing tools, and never adds
 `.copier-answers.yml`. The handoff explicitly says the project is selectively or
 core-toolchain aligned rather than template-managed.
 
-### Flow 1: New project ("set me up from scratch")
+### Flow 1: New Project ("Set Me Up from Scratch")
 
-The user pastes one thing into any agent (both variants in the README):
+The user pastes one thing into a compatible agent (both variants in the README):
 
 ```
 npx --yes skills@1.5.18 add jlevy/simple-modern-uv --skill simple-modern-uv --yes
@@ -162,48 +166,48 @@ npx --yes skills@1.5.18 add jlevy/simple-modern-uv --skill simple-modern-uv --ye
 (or, zero-install: *“Fetch the simple-modern-uv `SKILL.md` and its new-project reference
 from the same Git revision, then follow them to start a project called acme-widgets.”*)
 
-The agent then: infers author/email/org from the environment, asks the single batched
-round covering the essentials only (name normalization shown; description; license —
-default MIT; publish to PyPI? — default yes; org if not inferred), renders with
-`--data`, creates the initial commit, runs `make install`, verifies lint/tests pass, and
-offers the optional finish (create the GitHub repo and push; tag `v0.1.0` when ready to
-release; if publishing, point at `docs/publishing.md` for the one-time Trusted Publisher
-setup). Layout and initial version are conventions, not questions.
+The agent then infers author, email, and organization from the environment; asks one
+batched question covering name normalization, description, license (default MIT),
+publishing (default yes), and any organization it could not infer; renders with
+`--data`; creates the initial commit; runs `make install`; verifies lint and tests; and
+offers the optional finish: create and push the GitHub repo, tag `v0.1.0` when ready to
+release, and complete the one-time Trusted Publisher setup when publishing.
+Layout and initial version are conventions, not questions.
 
-### Flow 2: Upgrade an existing project ("modernize this repo")
+### Flow 2: Upgrade an Existing Project ("Modernize This Repo")
 
 The user pastes the install line plus: *“Upgrade this repo to follow simple-modern-uv
 best practices.”*
 
-Same interview, different answer source — the repo: name/description/authors from
+Same interview, different answer source—the repo: name/description/authors from
 `pyproject.toml` (or `setup.py`/`setup.cfg`), license from `LICENSE`/classifiers, org
 from the git remote, publish intent from PyPI presence or a `Private ::` classifier.
 The confirmation round presents the inferred essentials (name, description, license,
 publish intent) for sign-off.
-Migration mechanics follow the conventions tier — applied by default, reported in the
+Migration mechanics follow the conventions tier—applied by default, reported in the
 summary, never asked: migrate to `src/` layout; first tag set to the next sensible
 version above what’s published on PyPI (dynamic versioning needs a tag); raise
 `requires-python` to 3.11+. The one exception that *is* surfaced in the confirmation
 round: when raising the floor would drop Python versions a **published** package
-currently supports — shrinking a public support matrix is an essentials-tier decision,
-not a convention.
+currently supports—shrinking a public support matrix is an essentials-tier decision, not
+a convention.
 
-Then execute per `references/adopt-existing.md`: render the template into a temp dir
-with the confirmed answers; merge deliberately (template’s `pyproject.toml` structure
-with the project’s dependencies/metadata preserved; bring over `devtools/`, workflows,
-`Makefile`, docs stubs, `AGENTS.md`; write `.copier-answers.yml` with `_commit` so the
-project lands on the update path); translate tool configs (Poetry/PDM/setuptools → uv,
-mypy → basedpyright); remove superseded files (`poetry.lock`, old CI) — consulting
-`references/faq.md` for the common failure modes; verify; and land everything as one
-reviewable branch/commit.
+Then execute the
+[full-migration procedure](../../../../skills/simple-modern-uv/references/adopt-existing.md):
+render the template into a temporary directory with the confirmed answers; merge
+deliberately; preserve the project’s dependencies and metadata; add the relevant tools,
+workflows, docs, agent guidance, and honest Copier lineage; translate prior tool
+configuration; remove superseded files; consult the
+[FAQ](../../../../skills/simple-modern-uv/references/faq.md) for common failures;
+verify; and land everything as one reviewable branch or commit series.
 
-### Flow 3: Update an already-templated project ("pull the latest template")
+### Flow 3: Update an Already-Templated Project ("Pull the Latest Template")
 
-The user pastes: *“Update this project to the latest simple-modern-uv.”* No interview —
+The user pastes: *“Update this project to the latest simple-modern-uv.”* No interview—
 the answers are already recorded in `.copier-answers.yml`. The agent confirms a clean
 working tree, **reconciles any questions the template added since the project’s recorded
-version** (see D2’s answer-schema evolution rules: read the project’s actual state —
-LICENSE content, presence of `publish.yml`, `Private ::` classifier — and pass matching
+version** (see D2’s answer-schema evolution rules: read the project’s actual state—
+LICENSE content, presence of `publish.yml`, `Private ::` classifier—and pass matching
 `--data` so new questions can’t silently revert hand customizations), runs
 `uvx copier@<ver> update --defaults --data …` (optionally `--vcs-ref=<tag>`), resolves
 any conflict markers, re-runs lint/tests, and summarizes what changed against the
@@ -213,9 +217,9 @@ update forever**.
 
 ## Design
 
-### D1. One agent skill at `skills/simple-modern-uv/SKILL.md`
+### D1. One Agent Skill at `skills/simple-modern-uv/SKILL.md`
 
-A single skill folder, committed at the repo root in the universal discovery location:
+A single skill folder, committed in the repository’s portable skill location:
 
 ```
 skills/
@@ -251,16 +255,16 @@ Design rules (per `tbd guidelines cli-agent-skill-patterns`):
   and pre-approving a general package runner such as `uvx` would grant more execution
   authority than this skill needs.
   `name: simple-modern-uv` (must match the directory name).
-  The `description` follows the two-part rule — what it does plus explicit triggers
-  ("Use when creating a Python project, selectively adding repository practices,
-  migrating from Poetry/setuptools/pip/PDM/hatch, or updating a project managed by
+  The `description` follows the two-part rule: what it does plus explicit triggers ("Use
+  when creating a Python project, selectively adding repository practices, migrating
+  from Poetry/setuptools/pip/PDM/hatch, or updating a project managed by
   simple-modern-uv").
 - **Route, don’t restate**: the skill names and directly links each workflow; the
   selected one-level reference owns its exact commands and checklist.
   `copier.yml` remains the single source of truth for template questions.
   Body stays well under 500 lines; bulky checklists live in `references/`, one level
   deep.
-- **Pinned invocations**: every command in the skill pins versions
+- **Pinned invocations**: every package-runner command in the skill pins versions
   (`uvx copier@<X.Y.Z> copy gh:jlevy/simple-modern-uv …`), per the supply-chain rule
   that unpinned `uvx`/`npx` re-resolves to latest and bypasses any cool-off window.
 - **Complete bundle at one ref**: normal installation materializes `SKILL.md` and every
@@ -274,7 +278,7 @@ Copier lineage. Customization (license change, private/no-publish, app-vs-librar
 reachable from every relevant flow via `references/customize.md` plus the D2 template
 options.
 
-### D2. Template options for license and publishing
+### D2. Template Options for License and Publishing
 
 Two new copier questions (and only these two, preserving minimalism):
 
@@ -288,24 +292,24 @@ Two new copier questions (and only these two, preserving minimalism):
   (uncommented), and PyPI-specific README/badge content is omitted.
 
 Rationale: these must be template options rather than skill-guided post-render edits
-because `copier update` re-renders excluded-by-hand files — a deleted `publish.yml`
-would resurface on the next update.
+because `copier update` re-renders excluded-by-hand files—a deleted `publish.yml` would
+resurface on the next update.
 Conditional rendering keeps updates coherent.
 
 **Answer-schema evolution** (the standing rules for adding *any* question, these two
 included, so the upgrade path stays clean for existing projects):
 
 1. **Behavior-preserving defaults.** A new question’s default must reproduce exactly
-   what the template generated before the question existed (`MIT` + publish=true match
-   today’s unconditional output), so a vanilla project updating with `--defaults` gets a
-   no-op.
+   what the template generated before the question existed (`MIT` and
+   `publish_to_pypi=true` match today’s unconditional output), so a vanilla project
+   updating with `--defaults` gets a no-op.
 2. **Old answer files stay valid.** Projects’ `.copier-answers.yml` files won’t contain
    the new keys; `copier update --defaults` fills them from defaults and records them.
    No migration scripts, no manual edits required.
 3. **The skill reconciles hand customizations.** Defaults can’t know about pre-options
    hand edits (a swapped LICENSE, a deleted `publish.yml`). Flow 3 therefore inspects
    the project’s actual state and passes explicit `--data` overrides for any new
-   question whose default contradicts observed reality — so an update can never silently
+   question whose default contradicts observed reality, so an update can never silently
    re-license a project or resurrect a deleted publish workflow.
    (Humans updating by hand get the same guidance in `updating.md` and the template
    release notes.)
@@ -316,23 +320,21 @@ included, so the upgrade path stays clean for existing projects):
 5. **Release-notes callout.** Any release that adds or changes questions says so
    explicitly, naming the new keys and their defaults.
 
-### D3. `AGENTS.md` in the template output
+### D3. `AGENTS.md` in the Template Output
 
-The template ships a concise `AGENTS.md` (~40–60 lines) in generated projects: uv
-workflow commands (`uv sync --all-extras`, `make lint`, `make test`, `uv run pytest`),
-src-layout conventions, lint/type-check expectations, and pointers into
-`docs/development.md`. The template also ships a two-line `CLAUDE.md` that imports
-`AGENTS.md` via Claude Code’s `@file` syntax (Claude Code doesn’t auto-read `AGENTS.md`,
-and committed symlinks behave poorly across platforms).
+The template ships a concise `AGENTS.md` in generated projects: uv workflow commands
+(`uv sync --all-extras`, `make lint`, `make test`, `uv run pytest`), src-layout
+conventions, lint/type-check expectations, and pointers into `docs/development.md`. The
+template also ships a two-line `CLAUDE.md` that imports `AGENTS.md` via Claude Code’s
+`@file` syntax (Claude Code doesn’t auto-read `AGENTS.md`, and committed symlinks behave
+poorly across platforms).
 Unconditional (deletable), like the other starter docs.
-This reverses the early-2025 removal of agent rules, justified by the format’s
-standardization (see Background).
 
-### D4. Remove `uvtemplate` entirely
+### D4. Remove `uvtemplate` Entirely
 
 The agent workflows fully subsume what `uvtemplate` did (its value was the guided
 interview, and the interview contract moves that into the agent), so it is removed
-rather than demoted — all tooling consolidates in this repo, and no second wrapper CLI
+rather than demoted—all tooling consolidates in this repo, and no second wrapper CLI
 remains to maintain.
 
 In this repo, every `uvtemplate` reference goes away: the PyPI badge in the README
@@ -342,7 +344,7 @@ section, the old “Option 1: Run `uvx uvtemplate`”, and the cross-references 
 
 - **Option 1: use your agent.** The README routes new, selective, full-migration, and
   update requests through the installed skill, with a zero-install bundle-fetch variant.
-- **Option 2: copier by hand** (unchanged, for humans who want the terminal — this was
+- **Option 2: copier by hand** (unchanged, for humans who want the terminal—this was
   always what `uvtemplate` wrapped).
 - **Option 3: GitHub template repo** (unchanged).
 
@@ -352,15 +354,18 @@ CLI prints the same pointer, then archive the repo.
 Existing installs keep working; `.copier-answers.yml` files it wrote remain valid for
 Flow 3 updates, so no user is stranded.
 
-### D5. CI for this repo (render smoke test + skill validation)
+### D5. CI for This Repo (Render Smoke Test and Skill Validation)
 
-This repo currently has no CI; validation is manual via the downstream
-`simple-modern-uv-template` repo (release gate, per `updating.md`). Add a `ci.yml` to
-this repo that on every push/PR:
+At the start of this work, validation was manual through the downstream
+`simple-modern-uv-template` repo.
+The implementation includes
+[`.github/workflows/ci.yml`](../../../../.github/workflows/ci.yml), which runs on every
+push and pull request while preserving the downstream release gate in
+[updating.md](../../../../updating.md):
 
 1. Renders the template with `copier copy --defaults` (plus a second render with
    non-default options: proprietary license, `publish_to_pypi=false`) into temp dirs.
-2. In the default render: `uv sync --all-extras`,
+2. In the default render: `uv sync --locked --all-extras --all-groups`,
    `uv run python devtools/lint.py --check`, `uv run pytest`, `uv build` (with
    `UV_EXCLUDE_NEWER` set, matching template CI).
 3. Runs the update-path test (D2 rule 4): render at the previous release tag, then
@@ -373,17 +378,19 @@ this repo that on every push/PR:
 The downstream repo remains the release gate for tagged releases; this CI makes PRs
 self-validating. `updating.md` is updated to reflect the new split.
 
-### D6. Version currency
+### D6. Version Currency
+
+The initial 2026-06-11 currency plan was:
 
 - Bump the uv pin in `template/.github/workflows/ci.yml` and `publish.yml` from 0.11.12
   to the newest version that clears the 14-day cool-off at implementation time (0.11.x
   series; 0.11.20 was released 2026-06-10 and is too fresh as of this writing).
 - Review dev-dependency floors (`ruff`, `basedpyright`, `pytest`, etc.)
-  the same way — floors are `>=`, so this is routine; the cool-off applies to what CI
+  the same way—floors are `>=`, so this is routine; the cool-off applies to what CI
   resolves, via `UV_EXCLUDE_NEWER`.
 - Check `astral-sh/setup-uv` for a newer immutable tag.
-- Appendix A’s action items capture anything structural uv has added that the template
-  should adopt or explicitly decline.
+- The maintained [uv changes research](../../research/research-uv-changes.md) captures
+  structural changes the template should adopt or explicitly decline.
 
 **2026-08-14 follow-up:** the next focused currency cycle advances the eligible uv pin
 to 0.12.0, reviews the 0.12 compatibility changes, updates the supporting tool and
@@ -395,19 +402,19 @@ See the
 [v0.5.0 supply-chain manifest](../../research/research-v0.5.0-supply-chain-manifest.md)
 and the maintained [uv changes research](../../research/research-uv-changes.md).
 
-### D7. basedpyright stays; refresh the research doc
+### D7. Keep BasedPyright and Refresh the Research
 
-Per `docs/project/research/research-python-type-checkers.md` (updated 2026-06-01),
-BasedPyright remains the default: it inherits Pyright’s ~98% typing-spec conformance
-while ty is still beta and materially behind.
-Work here is a light refresh: re-check conformance numbers and ty/Pyrefly status, bump
-the basedpyright floor past 1.39.x as the cool-off allows, and re-review the
-commented-out rule toggles in `pyproject.toml.jinja` against current basedpyright
-defaults. No checker switch.
+Per the [type-checker research](../../research/research-python-type-checkers.md)
+(updated 2026-06-01), BasedPyright remains the default: it inherits Pyright’s ~98%
+typing-spec conformance while ty is still beta and materially behind.
+The review re-checks conformance data and ty/Pyrefly status, and re-reviews the
+commented-out rule toggles in `pyproject.toml.jinja` against current BasedPyright
+defaults. The 2026-08-14 freeze keeps the `>=1.39.9` floor because 1.39.10 missed the
+cutoff. No checker switch.
 
 ## Implementation Plan
 
-### Phase 1: The skill and its docs
+### Phase 1: The Skill and Its Docs
 
 - [x] Write `skills/simple-modern-uv/SKILL.md` (frontmatter per D1; adoption levels,
   shared contracts, and routing for all four flows)
@@ -422,12 +429,12 @@ defaults. No checker switch.
   real migration reports)
 - [ ] Test activation per the guideline: positive/negative prompts, explicit invocation,
   and a real end-to-end run of each flow in a scratch repo
-- [x] README: agent-first “Option 1” with per-flow paste blocks (install line + one-line
-  prompt for new/upgrade/update, plus the zero-install raw-URL variant); remove all
-  uvtemplate references including the PyPI badge and “In a Hurry?”
+- [x] README: agent-first discovery, one reviewed install command, a four-workflow
+  prompt table, and the zero-install same-ref variant; remove all uvtemplate references
+  including the PyPI badge and “In a Hurry?”
   section (D4); remove uvtemplate cross-references from `template/docs/publishing.md`
 
-### Phase 2: Template changes
+### Phase 2: Template Changes
 
 - [x] Add `package_license` and `publish_to_pypi` copier questions; conditional
   `LICENSE`, `publish.yml`, `docs/publishing.md`, classifier and README content;
@@ -439,27 +446,26 @@ defaults. No checker switch.
 - [x] Refresh basedpyright config comments and the type-checker research doc (D7)
 - [ ] Validate via the downstream repo flow in `updating.md`
 
-### Phase 3: Repo CI and maintenance docs
+### Phase 3: Repo CI and Maintenance Docs
 
-- [x] Add `.github/workflows/ci.yml` to this repo: default + non-default renders,
+- [x] Add `.github/workflows/ci.yml` to this repo: default and non-default renders,
   lint/test/build on the render, skill validation, `make format-check` (D5)
 - [x] Update `updating.md`: PR validation now automatic; downstream repo remains the
   release gate; add the skill to the release checklist; add the D2 answer-schema
   evolution rules as a standing policy for future question changes
 - [x] Add the uv-changes research doc (`docs/project/research/research-uv-changes.md`)
   as a living doc seeded from Appendix A
-- [ ] Follow-up (outside this repo): retire jlevy/uvtemplate — deprecation note in its
+- [ ] Follow-up (outside this repo): retire jlevy/uvtemplate—deprecation note in its
   README, final PyPI release printing a pointer here, archive the repo (D4)
 
 ## Testing Strategy
 
 - **Template renders**: CI renders both the default and the proprietary/no-publish
   variants and runs the full `sync → lint --check → pytest → build` cycle on the default
-  render (Phase 3 makes this automatic; until then, run manually as in `updating.md`
-  Step 5).
+  render.
 - **Update path**: CI’s update-path test (D2 rule 4) guards every future template
-  change, not just this one — render at the previous tag, update to the candidate,
-  vanilla no-op asserted.
+  change, not just this one—render at the previous tag, update to the candidate, vanilla
+  no-op asserted.
 - **Skill validation**: `npx skills-ref validate` in CI; link/reference resolution
   check.
 - **Skill behavior**: manual end-to-end runs of all four User Flows with a real agent
@@ -473,13 +479,13 @@ defaults. No checker switch.
 ## Rollout Plan
 
 1. Land Phases 1–3 on this repo (skill is immediately installable from `main` once
-   merged — `npx skills add` tracks the repo).
+   merged—`npx skills add` tracks the repo).
 2. Run the `updating.md` release flow: export to the downstream repo, wait for CI, then
    tag a release.
 3. After the release: verify
    `npx skills add jlevy/simple-modern-uv --skill simple-modern-uv --yes` end-to-end
    from a clean environment, then retire uvtemplate (deprecation note, final pointer
-   release, archive — D4).
+   release, archive—D4).
 4. Optional later: submit to the Anthropic community plugin marketplace
    (`clau.de/plugin-directory-submission`) for reviewed, security-screened
    discoverability inside Claude Code.
@@ -489,90 +495,38 @@ defaults. No checker switch.
 ## Open Questions
 
 - **Claude plugin marketplace**: ship `.claude-plugin/marketplace.json` now, or wait?
-  Recommendation: wait — repo-local installs and `npx skills add` need no manifest, and
+  Recommendation: wait—repo-local installs and `npx skills add` need no manifest, and
   the community-marketplace submission (rollout step 4) is the higher-trust channel if
   we want in-Claude discovery later.
 - **Skill name**: `simple-modern-uv` (matches repo, required to match its directory).
   Alternative trigger-richer names (e.g. `modern-python-project`) were considered; the
   description carries the triggers, so the repo-matching name wins for recognizability.
 
-## Appendix A: uv Changes Since March 2025
+## Appendix A: uv Research
 
-When this template was created (March 2025), uv was on 0.6.x. As of 2026-06-11 the
-latest is **0.11.20** (released 2026-06-10). Notable changes by series, focused on what
-matters to this template (compiled from release notes and the Astral blog; to be
-maintained as a living doc in `docs/project/research/research-uv-changes.md` per Phase
-3):
-
-- **0.6.x (Feb–Apr 2025)**: `uv publish` stabilized out of preview (the template’s
-  publish flow rests on this).
-  Lockfile gained a `revision` field.
-  Stricter validation of extras/groups.
-- **0.7.x (Apr–Jul 2025)**: `uv version` redesigned to read/bump the *project* version
-  (`uv self version` for uv itself); `--bump major/minor/patch` added.
-  Auth failures (401/403) now halt index search.
-  **`uv_build` declared stable** (0.7.19): a fast, pure-Python-only build backend.
-- **0.8.x (Jul–Oct 2025)**: **`uv_build` became the default backend for
-  `uv init --package`/`--lib`** (hatchling remains fully supported).
-  `uv python install` installs versioned executables (`python3.13`) onto PATH by
-  default. **`uv format` introduced** (preview; delegates to a pinned Ruff).
-- **0.9.x (Oct 2025–Feb 2026)**: default Python bumped to **3.14** (3.14.0 final, Oct
-  2025); free-threaded 3.14+ usable without opt-in.
-- **0.10.x (Feb–Mar 2026)**: `uv python upgrade`, `uv add --bounds`, and
-  `uv workspace list/dir` stabilized.
-  `uv venv` requires `--clear` to overwrite.
-  `uv format` moved to Ruff 0.15 / 2026 style.
-- **0.11.x (Mar 2026–now)**: TLS moved to OS-native verification (`--native-tls`
-  deprecated for `--system-certs`). **`uv audit`** (preview; announced 2026-06-08):
-  scans `uv.lock` against the OSV database, with `--ignore`/`--ignore-until-fixed`.
-  Opt-in **malware checks** on `uv add`/`uv sync` via `UV_MALWARE_CHECK=1` (0.11.16+).
-  **`uv check`** (0.11.18, preview): runs Astral’s ty type checker.
-  Python 3.15.0b2 in managed downloads; 3.15 final expected ~Oct 2026.
-
-Caveats: docs.astral.sh blocked automated fetching during research, so a few details
-(exact `uv audit` introduction version, full `[tool.uv]` option inventory) should be
-re-verified against the changelog during implementation.
-
-### Action items for this template
-
-1. **Stay on hatchling + uv-dynamic-versioning** (decision, documented in the research
-   doc): `uv_build` is now uv’s default backend and production-stable, but it is
-   deliberately minimal — no plugin mechanism, so no dynamic versioning from git tags,
-   which is core to this template’s release model.
-   Revisit if uv ever grows native dynamic versioning.
-2. **Add `[tool.uv] required-version`** (e.g. `>=0.11`) to
-   `template/pyproject.toml.jinja` so contributors and CI fail fast on incompatible uv
-   versions. (Folds into Phase 2 / D6.)
-3. **Watch `uv audit` and `UV_MALWARE_CHECK`**: both are preview and brand-new (audit
-   announced three days ago — inside the cool-off window).
-   Add a note to the template’s supply-chain docs now; adopt in template CI once stable.
-   (Folds into Phase 3 docs; CI adoption is a future release.)
-4. **Keep `devtools/lint.py` over `uv format`/`uv check`**: one command still runs
-   codespell + ruff check + ruff format + basedpyright together, which neither uv
-   command covers; `uv check` is also ty-based and preview (see D7). Mention both in
-   `docs/development.md` as aliases people may encounter.
-5. **Refresh `docs/installation.md`** for current `uv python install` behavior
-   (versioned executables on PATH since 0.8.0). (Folds into Phase 2.)
-6. **Python 3.15**: add to the CI matrix and classifiers when final (~Oct 2026) — a
-   future routine update, noted in `updating.md`’s checklist.
-7. **Bump the pinned uv** in template workflows from 0.11.12 to the newest 0.11.x
-   clearing the 14-day cool-off at implementation time (D6).
+The June 2026 design review began with uv 0.11.20 and produced the initial decisions in
+D6 and D7. The maintained [uv changes research](../../research/research-uv-changes.md)
+now owns the version timeline and current recommendations; the
+[v0.5.0 supply-chain manifest](../../research/research-v0.5.0-supply-chain-manifest.md)
+owns the 2026-08-14 dependency freeze and provenance record.
+Keeping those details out of this implementation spec keeps the current version guidance
+in one maintained place.
 
 ## References
 
-- `tbd guidelines cli-agent-skill-patterns` — skill/CLI integration patterns (the
+- `tbd guidelines cli-agent-skill-patterns`: skill and CLI integration patterns (the
   integration ladder, route-don’t-restate, publishing channels)
-- `tbd guidelines python-modern-guidelines` — Python/uv project conventions (cites this
-  template for releasing)
-- `tbd guidelines supply-chain-hardening` — pinning and cool-off policy
-- Agent Skills standard: https://agentskills.io (spec: /specification)
-- AGENTS.md standard: https://agents.md
-- skills installer: https://github.com/vercel-labs/skills (skills.sh)
-- Anthropic skills examples and marketplace: https://github.com/anthropics/skills
-- Copier docs (non-interactive: `--defaults`, `--data`, `--vcs-ref`; updates):
-  https://copier.readthedocs.io
-- Type-checker research: `docs/project/research/research-python-type-checkers.md`
-- Template maintenance flow: `updating.md`
+- `tbd guidelines python-modern-guidelines`: Python and uv project conventions (cites
+  this template for releasing)
+- `tbd guidelines supply-chain-hardening`: pinning and cool-off policy
+- [Agent Skills standard](https://agentskills.io) and
+  [specification](https://agentskills.io/specification)
+- [AGENTS.md standard](https://agents.md)
+- [skills installer](https://github.com/vercel-labs/skills)
+- [Anthropic skills examples and marketplace](https://github.com/anthropics/skills)
+- [Copier docs](https://copier.readthedocs.io) for non-interactive copies and updates
+- [Type-checker research](../../research/research-python-type-checkers.md)
+- [Template maintenance flow](../../../../updating.md)
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
+++ b/docs/project/specs/active/plan-2026-06-11-agent-skill-and-modernization.md
@@ -1,6 +1,6 @@
 # Feature: Agent Skill and Template Modernization
 
-**Date:** 2026-06-11 (last updated 2026-06-11, post-implementation)
+**Date:** 2026-06-11 (last updated 2026-08-14, post-implementation)
 
 **Author:** Joshua Levy (with agent assistance)
 
@@ -366,6 +366,13 @@ self-validating. `updating.md` is updated to reflect the new split.
 - Check `astral-sh/setup-uv` for a newer immutable tag.
 - Appendix A’s action items capture anything structural uv has added that the template
   should adopt or explicitly decline.
+
+**2026-08-14 follow-up:** the next focused currency cycle advances the eligible uv pin
+to 0.12.0, reviews the 0.12 compatibility changes, updates the supporting tool and
+action pins, and strengthens portable CI lockfile validation.
+See the
+[v0.5.0 supply-chain manifest](../../research/research-v0.5.0-supply-chain-manifest.md)
+and the maintained [uv changes research](../../research/research-uv-changes.md).
 
 ### D7. basedpyright stays; refresh the research doc
 

--- a/skills/simple-modern-uv/SKILL.md
+++ b/skills/simple-modern-uv/SKILL.md
@@ -75,7 +75,7 @@ These are never questions.
    Then render, replacing the answer values:
 
    ```bash
-   uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
+   uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
      --data package_name=acme-widgets \
      --data "package_description=One-line description" \
      --data "package_author_name=Jane Doe" \
@@ -131,7 +131,7 @@ Requires a clean working tree and the project’s `.copier-answers.yml`.
    [references/customize.md](references/customize.md)).
 
 2. ```bash
-   uvx --exclude-newer "14 days" copier@9.16.0 update --defaults --skip-answered
+   uvx --exclude-newer "14 days" copier@9.17.0 update --defaults --skip-answered
    ```
 
 3. Resolve any `*.rej` files or inline conflict markers, re-run `make lint` and

--- a/skills/simple-modern-uv/SKILL.md
+++ b/skills/simple-modern-uv/SKILL.md
@@ -1,149 +1,136 @@
 ---
 name: simple-modern-uv
 description: >-
-  Set up, modernize, or update Python projects using the simple-modern-uv template:
-  uv, ruff, BasedPyright, pytest, GitHub Actions CI, and tag-driven PyPI publishing.
-  Use when starting a new Python project or package; when modernizing, upgrading, or
-  migrating an existing Python package to uv (from Poetry, setuptools, pip,
-  requirements.txt, or PDM); or when updating a project already built from
-  simple-modern-uv to the latest template.
+  Start, selectively modernize, fully migrate, or update Python projects using
+  simple-modern-uv practices: uv, ruff, BasedPyright, pytest, GitHub Actions CI, and
+  tag-driven PyPI publishing. Use when creating a Python project; adding selected
+  tooling or repository practices to an existing project; migrating from Poetry,
+  setuptools, pip, requirements.txt, PDM, or hatch; or updating a project already
+  managed by the simple-modern-uv Copier template.
 license: MIT
 compatibility: Requires git and uv (https://docs.astral.sh/uv/); network access to GitHub
 metadata:
   author: jlevy (github.com/jlevy)
   source: https://github.com/jlevy/simple-modern-uv
-allowed-tools: Bash(uvx:*), Bash(uv:*), Bash(git:*), Bash(make:*), Bash(gh:*), Read, Write, Edit
 ---
 # simple-modern-uv: Modern Python Project Setup
 
 [simple-modern-uv](https://github.com/jlevy/simple-modern-uv) is a minimal, modern
-Python project template: **uv** for everything package-related, **ruff** for
-lint/format, **BasedPyright** for type checking, **pytest**, GitHub Actions CI, and
-tag-driven publishing to PyPI with dynamic versioning (the git tag is the version).
-It is a [Copier](https://copier.readthedocs.io) template, so projects can pull future
-template improvements at any time with `copier update`.
+Python project template: **uv** for package management, **ruff** for linting and
+formatting, **BasedPyright** for type checking, **pytest**, GitHub Actions CI, and
+tag-driven publishing to PyPI. It is a [Copier](https://copier.readthedocs.io) template,
+so fully managed projects can pull future template improvements with `copier update`.
 
-There are three workflows.
-Pick by situation:
+## Route the Request
 
-1. **New project**: create a project from scratch.
-2. **Upgrade existing project**: convert any existing Python package to this template’s
-   structure and tooling.
-   See [references/adopt-existing.md](references/adopt-existing.md).
-3. **Update templated project**: the project has a `.copier-answers.yml` from this
-   template; pull the latest template changes.
+Choose one workflow and load its reference before editing:
 
-For all workflows: when something fails, check [references/faq.md](references/faq.md)
-before improvising. For post-setup customization (license change, private/unpublished
-package, entry points), see [references/customize.md](references/customize.md).
+| User goal | Workflow |
+| --- | --- |
+| Start a project from scratch | [Start a new project](references/start-new-project.md) |
+| Add one or more practices without restructuring everything | [Adopt selected features](references/adopt-selectively.md) |
+| Convert an existing package to the template’s structure and update path | [Upgrade an existing project](references/adopt-existing.md) |
+| Pull upstream changes into a project with `.copier-answers.yml` | [Update a template-managed project](references/update-templated-project.md) |
+
+Use [references/customize.md](references/customize.md) for license, publishing, apps,
+and common policy changes.
+When something fails, consult [references/faq.md](references/faq.md) before improvising.
 
 If this file was fetched from a URL rather than installed as a folder, fetch the
-reference files from the **same ref**: replace `SKILL.md` in the URL you used with
-`references/<name>.md` (don’t mix a pinned `SKILL.md` with references from `main`).
+selected reference and any shared reference it names from the **same Git ref**. Never
+mix a pinned `SKILL.md` with references from `main`.
 
-## The Interview: What to Ask the User (and What Not to Ask)
+## Choose the Lowest Useful Adoption Level
 
-Every workflow uses the same answer set (the template’s questions in
-[copier.yml](https://github.com/jlevy/simple-modern-uv/blob/main/copier.yml)). **Infer
-everything you can, then ask the user to confirm once, in a single batched message.**
-Never ask one question at a time, and never ask about things listed under “conventions”
-below.
+These are working modes, not certifications:
 
-**Essentials** (confirm these; they are the user’s decisions):
+| Level | Result |
+| --- | --- |
+| **Selective** | Adopt only named feature bundles. Preserve the current build backend, layout, release model, and equivalent tools unless the user asks to change them. Do not add `.copier-answers.yml`. |
+| **Core toolchain** | Adopt uv dependency management, lockfile policy, lint/type/test commands, CI, and agent guidance. Preserve packaging, versioning, or layout where changing them has no stated benefit. This is not Copier-managed unless the user chooses full migration. |
+| **Full template-managed** | Render or migrate to the template structure, record `.copier-answers.yml`, and use Copier for future updates. Explicitly document any deliberate deviations. |
+
+Choose the lowest level that satisfies the request.
+A named feature request is selective by default.
+“Upgrade/migrate this project to simple-modern-uv” means full migration unless
+repository constraints make a lower level safer; surface that change of scope before
+acting.
+
+## Inspect Before Acting
+
+For an existing repository, inspect its instructions and working tree first.
+Then map:
+
+- project metadata, dependencies, Python support, package layout, and build backend
+- current lockfiles, environment manager, linting, typing, tests, and CI
+- versioning, release, publishing, license, private-index, and platform constraints
+- existing `AGENTS.md`, `CLAUDE.md`, `.copier-answers.yml`, and local modifications
+
+Preserve user work and established behavior.
+Work on a branch, and never overwrite an existing configuration merely because the
+template has a different default.
+
+## Interview Contract
+
+New projects and full migrations use the template questions in
+[`copier.yml`](https://github.com/jlevy/simple-modern-uv/blob/main/copier.yml).
+Infer everything possible, then ask the user to confirm material choices once in one
+batched message.
 
 | Answer key | Meaning | Notes |
 | --- | --- | --- |
-| `package_name` | PyPI package and GitHub repo name | Normalize to **kebab-case** (`acme-widgets`); show the user the name you derived |
-| `package_module` | Python module name | Derived automatically as **snake_case** (`acme_widgets`); show it, don’t ask |
-| `package_description` | One-line description |  |
-| `package_license` | `MIT` (default), `Apache-2.0`, `BSD-3-Clause`, `AGPL-3.0-or-later`, `Proprietary`, or `None` (decide later) | Always surface, naming the default |
-| `publish_to_pypi` | `true` (default) or `false` | Always surface; `false` for private packages and apps |
+| `package_name` | PyPI package and GitHub repo name | Normalize to **kebab-case** and show the derived name |
+| `package_module` | Python module name | Derive **snake_case** from the package name; show it, do not ask |
+| `package_description` | One-line description | Infer from existing metadata when possible |
+| `package_license` | MIT, Apache-2.0, BSD-3-Clause, AGPL-3.0-or-later, Proprietary, or None | Always surface, naming MIT as the new-project default |
+| `publish_to_pypi` | `true` or `false` | Always surface; use `false` for private packages and unpublished apps |
 
-For `package_author_name`, `package_author_email`, and `package_github_org`, **infer**
-values from `git config user.name` and `user.email` and the repo’s remote or
-`gh auth status`, and include them in the confirmation summary rather than asking.
+Infer author name, author email, and GitHub organization from project metadata, git, the
+remote, and authenticated GitHub state.
+Include the inferred values in the confirmation summary rather than asking separately.
 
-**Conventions** (apply silently; mention in your final summary; deviate only if the user
-explicitly asks): `src/` layout; first version is the git tag `v0.1.0` for a new project
-(for upgrades of published packages, the next version above what’s on PyPI); Python
-3.11+; line length 100; the template’s tool choices.
-These are never questions.
+For new projects, apply the template conventions: `src/` layout, Python 3.11+, line
+length 100, and tag-derived versions beginning with `v0.1.0`. For published migrations,
+the next tag must exceed the published version.
+For selective and core adoption, preserve existing choices unless the requested feature
+requires a change; ask only about those material conflicts.
 
-## Workflow 1: New Project
+Always surface changes to supported Python versions, package layout, build backend,
+versioning, license, publishing, or CI provider.
+These are project decisions, not incidental implementation details.
 
-1. Run the interview (above).
-   Then render, replacing the answer values:
+## Shared Execution Contract
 
-   ```bash
-   uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
-     --data package_name=acme-widgets \
-     --data "package_description=One-line description" \
-     --data "package_author_name=Jane Doe" \
-     --data package_author_email=jane@example.com \
-     --data package_github_org=acme \
-     --data package_license=MIT \
-     --data publish_to_pypi=true \
-     gh:jlevy/simple-modern-uv acme-widgets
-   ```
+- Use the repository’s reviewed, pinned Copier command and 14-day dependency cool-off.
+- Render the template to a temporary sibling directory when a reference implementation
+  is useful. Compare and adapt; do not blindly copy over an existing project.
+- Adopt each feature’s complete dependency closure.
+  For example, a locked CI workflow also needs compatible project metadata, `uv.toml`,
+  `uv.lock`, and commands.
+- Keep equivalent existing tooling when replacement is outside the requested scope.
+- Add `.copier-answers.yml` only for a deliberate full migration.
+  Selective copying does not create honest Copier lineage and must not pretend that it
+  does.
+- Keep changes reviewable and report conflicts or deliberate deviations explicitly.
 
-   (Omit `--data` keys that should take defaults.
-   `package_module` derives automatically from `package_name`.)
+## Verification and Handoff
 
-2. Initialize git, commit, then install.
-   Sync only after the first commit: dynamic versioning reads git, and syncing first
-   leaves the editable install’s version at `0.0.0`.
+Verify every touched path.
+Full and core adoption normally require `make install`, `make lint`, and `make test`;
+publishable projects also require `make build`. Selective adoption runs the smallest
+commands that prove the selected features and their failure paths.
+Validate workflow syntax and preserve existing tests whenever CI changes.
 
-   ```bash
-   cd acme-widgets
-   git init --initial-branch=main
-   git add . && git commit -m "Initial commit from simple-modern-uv."
-   make install
-   git add uv.lock && git commit -m "Add uv.lock."
-   ```
+Before reporting success, summarize five categories:
 
-3. **Verify**: `make lint` and `make test` must pass.
-   Fix anything that doesn’t before declaring success.
+- **Adopted**: template practices used as designed
+- **Adapted**: practices adjusted to preserve project constraints
+- **Preserved**: existing choices or equivalent tools intentionally retained
+- **Deferred**: relevant practices intentionally left for later
+- **Removed**: superseded files or tooling, if any
 
-4. Offer next steps (don’t just stop): create the GitHub repo and push (an empty repo
-   with no README, license, or .gitignore; the template provides them); fill in
-   `README.md`; if publishing, `docs/publishing.md` covers the one-time PyPI Trusted
-   Publisher setup; tag `v0.1.0` when ready to release.
-
-## Workflow 2: Upgrade an Existing Project
-
-Follow [references/adopt-existing.md](references/adopt-existing.md).
-In brief: run the interview with answers **inferred from the repo itself**
-(pyproject/setup.py metadata, LICENSE file, git remote, PyPI presence), render the
-template into a sibling temp directory with those answers, merge the template’s
-structure into the project (preserving its dependencies, metadata, and code), translate
-old tool configs to uv equivalents, write `.copier-answers.yml` so future updates work,
-and verify with `make install`, lint, and tests.
-Land everything on a branch as one reviewable change.
-
-## Workflow 3: Update a Templated Project
-
-Requires a clean working tree and the project’s `.copier-answers.yml`.
-
-1. If the template has questions the project has never answered (keys present in the
-   template’s `copier.yml` but missing from the project’s `.copier-answers.yml`), first
-   check the project’s actual state and pass matching `--data` so defaults can’t revert
-   hand customizations (see “Reconciling New Questions on Update” in
-   [references/customize.md](references/customize.md)).
-
-2. ```bash
-   uvx --exclude-newer "14 days" copier@9.17.0 update --defaults --skip-answered
-   ```
-
-3. Resolve any `*.rej` files or inline conflict markers, re-run `make lint` and
-   `make test`, then summarize what the template update changed (check the
-   [release notes](https://github.com/jlevy/simple-modern-uv/releases)).
-
-## Verification Gate (All Workflows)
-
-Before reporting success: `make install`, `make lint`, and `make test` all pass, and for
-publishable packages `make build` produces a wheel with a sensible version (requires at
-least one git commit; see the FAQ if the version looks wrong).
-Report what you ran and the results.
+Also state whether the result is selective, core, or full template-managed; list the
+validation commands and outcomes; and name any decision that still belongs to the user.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -9,7 +9,7 @@ Work on a branch and land the whole migration as one reviewable change.
 This is the **full template-managed** workflow: it deliberately creates honest Copier
 lineage for future updates.
 If the user only wants selected features or wants to keep the current project structure,
-use `adopt-selectively.md` instead.
+use [adopt-selectively.md](adopt-selectively.md) instead.
 
 Out of scope (stop and tell the user): C extensions or custom build steps, conda
 environments, monorepos/workspaces with multiple packages.
@@ -27,7 +27,7 @@ These need decisions a checklist shouldn’t make.
 | `publish_to_pypi` | `true` if the package is on PyPI (`uv pip index` or check pypi.org) or clearly intended for it; `false` for apps/private code (a `Private :: Do Not Upload` classifier is a definitive no) |
 
 Confirm the essentials with the user in one batched message (per the interview contract
-in SKILL.md), flagging anything that will change.
+in [SKILL.md](../SKILL.md)), flagging anything that will change.
 One decision that must be surfaced if it applies: if the project currently supports
 Python older than 3.11 **and** is published, adopting the template raises
 `requires-python` to `>=3.11`. Dropping versions for existing users is the user’s call,
@@ -141,7 +141,7 @@ If legacy code produces a wall of errors, see the FAQ: relax first, ratchet late
 
 ```bash
 make install               # creates uv.lock; commit it
-make lint                  # codespell + ruff + basedpyright
+make lint                  # codespell, ruff, and basedpyright
 make test
 make build                 # only if publishing
 ```

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -6,6 +6,11 @@ The approach: render the template next to the project, then merge it in delibera
 never blindly overwrite.
 Work on a branch and land the whole migration as one reviewable change.
 
+This is the **full template-managed** workflow: it deliberately creates honest Copier
+lineage for future updates.
+If the user only wants selected features or wants to keep the current project structure,
+use `adopt-selectively.md` instead.
+
 Out of scope (stop and tell the user): C extensions or custom build steps, conda
 environments, monorepos/workspaces with multiple packages.
 These need decisions a checklist shouldn’t make.
@@ -27,6 +32,11 @@ One decision that must be surfaced if it applies: if the project currently suppo
 Python older than 3.11 **and** is published, adopting the template raises
 `requires-python` to `>=3.11`. Dropping versions for existing users is the user’s call,
 not yours.
+
+Also surface changes to package layout, build backend, version source, CI provider, and
+publishing. Full adoption normally uses the rendered choices, but preserve a deliberate
+project-specific exception and record it as an adaptation when replacement has no agreed
+benefit.
 
 ## Step 2: Render the Template Beside the Project
 
@@ -98,6 +108,27 @@ Copy from the render, adapting as you go:
   `[dependency-groups] dev`. Drop exact `==` pins unless genuinely required; `uv.lock`
   provides reproducibility.
 
+**PDM**:
+
+- Preserve an existing PEP 621 `[project]` table; move `[tool.pdm.dev-dependencies]`
+  into `[dependency-groups]` and replace `pdm.lock` with `uv.lock`.
+- Review `[tool.pdm.scripts]` individually.
+  Package entry points belong in `[project.scripts]`; development task aliases belong in
+  the Makefile or project docs.
+  Do not turn arbitrary shell tasks into installed commands.
+- Replacing `pdm-backend` with Hatchling and tag-derived versions is a release-model
+  change covered by the confirmation step, not a mechanical dependency translation.
+
+**Hatch**:
+
+- Keep compatible Hatchling build configuration and merge the rendered package path and
+  dynamic-versioning settings deliberately.
+- Translate Hatch environment dependencies into uv dependency groups and useful Hatch
+  scripts into Make targets.
+  Remove environment configuration only after every relied-on command has an equivalent.
+- If the project uses a static or file-based version, changing it to git tags is a
+  release-model decision that must be confirmed.
+
 **mypy → BasedPyright**: drop `mypy.ini`/`[tool.mypy]`; the rendered
 `[tool.basedpyright]` block is the starting point.
 Existing `# type: ignore` comments still work.
@@ -127,8 +158,9 @@ don’t rewrite working code just to satisfy a rule.
   project starts at `v0.1.0`. Until a tag exists, builds get a dev version: fine for CI,
   wrong for release.
 - Commit everything (including `uv.lock` and `.copier-answers.yml`) on the branch and
-  summarize: what moved, what was translated, what was deleted, anything the user should
-  review by hand (license, classifiers, CI triggers).
+  summarize what was adopted, adapted, preserved, deferred, and removed, plus anything
+  the user should review by hand (license, classifiers, CI triggers).
+  State that the result is full template-managed and name any deliberate deviations.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/skills/simple-modern-uv/references/adopt-existing.md
+++ b/skills/simple-modern-uv/references/adopt-existing.md
@@ -32,7 +32,7 @@ not yours.
 
 ```bash
 cd ..
-uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
+uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
   --data package_name=<name> ... \
   gh:jlevy/simple-modern-uv <project>-template-render
 ```
@@ -47,15 +47,15 @@ Copy from the render, adapting as you go:
 - **`pyproject.toml`**: start from the rendered one and port the project’s reality into
   it: `dependencies`, extras, entry points, tool configs that should survive (translate
   as below). Keep the rendered `[build-system]` (hatchling with uv-dynamic-versioning),
-  `[tool.uv]`, `[tool.ruff]`, `[tool.basedpyright]`, `[tool.pytest.ini_options]`
-  sections.
+  `[tool.ruff]`, `[tool.basedpyright]`, and `[tool.pytest.ini_options]` sections.
 - **Code layout**: move code to `src/<module>/` (the convention; if the user insists on
   a flat layout, adjust `packages` and `testpaths` instead).
   Ensure `py.typed` exists in the package.
   Tests go in `tests/`.
-- **Copy verbatim**: `devtools/lint.py`, `Makefile`, `.gitignore` (merge with existing
-  entries), `.github/workflows/ci.yml` (and `publish.yml` if publishing),
-  `docs/installation.md`, `docs/development.md`.
+- **Copy verbatim**: `uv.toml`, `devtools/lint.py`, `Makefile`, `.gitignore` (merge with
+  existing entries), `.github/workflows/ci.yml` (and `publish.yml` if publishing),
+  `docs/installation.md`, `docs/development.md`. Put project-specific uv indexes and
+  other resolution settings in `uv.toml` so the Makefile and CI use them consistently.
 - **Agent instruction files**: copy `AGENTS.md` and `CLAUDE.md` from the render if the
   project has neither.
   If the project already has an `AGENTS.md`, keep its content and fold in the template’s

--- a/skills/simple-modern-uv/references/adopt-selectively.md
+++ b/skills/simple-modern-uv/references/adopt-selectively.md
@@ -1,0 +1,72 @@
+# Adopting Selected simple-modern-uv Features
+
+Use this workflow when the user wants specific practices without restructuring the whole
+repository or enrolling it in Copier updates.
+Preserve the project’s existing architecture and choose the smallest coherent set of
+changes.
+
+If the user instead wants the repository fully converted and updateable through Copier,
+use `adopt-existing.md`.
+
+## Feature Bundles and Dependencies
+
+Treat each row as a coherent bundle.
+Adapt filenames and commands to existing project conventions rather than assuming every
+file must be copied verbatim.
+
+| Feature | Reference pieces | Dependencies and boundaries |
+| --- | --- | --- |
+| Agent guidance | `AGENTS.md`; optional `CLAUDE.md` import | Preserve existing agent instructions and merge only durable commands and conventions |
+| uv dependency management | `uv.toml`, `uv.lock`, PEP 621 dependencies and groups, install/upgrade Make targets | Does not require changing a working build backend, package layout, or versioning scheme |
+| Linting and typing | `devtools/lint.py`, Ruff, codespell, BasedPyright settings and dev dependencies, lint Make targets | Adopt individual tools only when requested; translate existing ignores and avoid a repository-wide cleanup unrelated to the request |
+| Tests | pytest dependencies and settings, `tests/`, test Make target | Preserve the existing test layout and plugins unless they conflict |
+| GitHub Actions CI | pinned checkout/setup-uv actions, Python matrix, locked install, lint and test steps | Requires commands and lock policy that work locally; adapt rather than duplicate an existing workflow |
+| Packaging and versions | Hatchling, uv-dynamic-versioning, locked build group, tag-derived versions | Material release-model change; require explicit user agreement before replacing another backend or version source |
+| PyPI publishing | OIDC workflow and `docs/publishing.md` | Requires compatible packaging/versioning and explicit intent to publish; omit for private projects and unpublished apps |
+| Developer docs | README links plus installation, development, and publishing guides | Merge useful sections; never replace substantive project documentation with template placeholders |
+| Supply-chain policy | 14-day resolution cool-off, reviewed pins, checksums, full action SHAs, locked CI | Apply to the package runner and CI paths actually adopted by the project |
+| Template lineage | `.copier-answers.yml` | **Never adopt ad hoc.** It is valid only after a deliberate full migration or fresh render |
+
+## Workflow
+
+1. Read repository instructions and inspect the working tree, package metadata,
+   dependency files, tool configuration, CI, and the exact feature request.
+
+2. State the inferred adoption level and map each relevant bundle to **adopt**,
+   **adapt**, **preserve**, or **defer**. Ask once about any material choice, such as
+   replacing a build backend, changing supported Python versions, or removing an
+   established tool.
+
+3. If upstream files are useful as a reference, render the pinned template into a
+   temporary sibling directory.
+   Do not render over the target repository.
+
+   ```bash
+   uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
+     --data package_name=<existing-package-name> \
+     --data package_github_org=<existing-org> \
+     gh:jlevy/simple-modern-uv ../<project>-smu-reference
+   ```
+
+4. Apply the smallest complete dependency closure.
+   Merge configuration into existing files, retain project-specific settings, and avoid
+   drive-by source formatting or type fixes.
+
+5. Validate the selected feature locally.
+   If CI changes, run the same install, lint, and test commands outside CI and parse the
+   workflow YAML. If packaging changes, build both wheel and sdist.
+
+6. Summarize adopted, adapted, preserved, deferred, and removed pieces.
+   State explicitly that the project is selectively or core-toolchain aligned and is
+   **not** Copier-managed.
+
+## Moving to Full Adoption Later
+
+Selective adoption is intentionally reversible.
+A later full migration should render the then-current template, compare it with the
+project, preserve the adaptations made here, and only then add `.copier-answers.yml`. Do
+not manufacture template history from the files copied during selective adoption.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/skills/simple-modern-uv/references/adopt-selectively.md
+++ b/skills/simple-modern-uv/references/adopt-selectively.md
@@ -6,7 +6,7 @@ Preserve the project’s existing architecture and choose the smallest coherent 
 changes.
 
 If the user instead wants the repository fully converted and updateable through Copier,
-use `adopt-existing.md`.
+use [adopt-existing.md](adopt-existing.md).
 
 ## Feature Bundles and Dependencies
 

--- a/skills/simple-modern-uv/references/customize.md
+++ b/skills/simple-modern-uv/references/customize.md
@@ -4,6 +4,8 @@ Common customizations after (or during) setup.
 Where a customization maps to a template question, prefer answering the question over
 hand-editing: hand edits to template-managed files can be reverted by a later
 `copier update` (see “Reconciling New Questions on Update” below).
+For selective adoption without `.copier-answers.yml`, edit the project normally and
+record the choice as an adaptation; Copier does not own those files.
 
 ## Changing the License
 

--- a/skills/simple-modern-uv/references/customize.md
+++ b/skills/simple-modern-uv/references/customize.md
@@ -12,7 +12,7 @@ Preferred: set the `package_license` answer (`MIT`, `Apache-2.0`, `BSD-3-Clause`
 re-answer it later with:
 
 ```bash
-uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=Apache-2.0
+uvx --exclude-newer "14 days" copier@9.17.0 update --data package_license=Apache-2.0
 ```
 
 This updates the `LICENSE` file and the `license` field in `pyproject.toml` together,
@@ -50,7 +50,7 @@ visibly deviates from a fresh render, make the answer explicit.
 ## Apps and CLIs (vs. Libraries)
 
 - Entry points live in `[project.scripts]`: `mycli = "my_module.cli:main"`; then
-  `uv run mycli` works and installs expose the command.
+  `UV_CONFIG_FILE=uv.toml uv run mycli` works and installs expose the command.
 - An app that’s not a library usually wants `publish_to_pypi=false`; it still gets the
   full dev workflow.
 - For a long-lived service, consider pinning the Python version with a `.python-version`

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -23,14 +23,15 @@ No git tag yet: dynamic versioning derives the version from the latest `v*` tag.
   `fetch-depth: 0` (the template’s workflows do) so tags are available.
 - `importlib.metadata` still reports an old version after committing or tagging: the
   editable install’s metadata is captured at sync time and uv won’t refresh it on its
-  own. Run `uv sync --reinstall-package <module>` (and sync only after the first commit
-  on new projects).
+  own. Run `UV_CONFIG_FILE=uv.toml uv sync --reinstall-package <module>` (and sync only
+  after the first commit on new projects).
 
 ## `uv sync` Fails on Python Version
 
-The template requires Python 3.11+. `uv python install` downloads a managed interpreter;
-pin one for the project with `uv python pin 3.12` (writes `.python-version`). If uv
-itself errors with “required-version”, upgrade uv: the template requires uv >= 0.9.
+The template requires Python 3.11+. `UV_CONFIG_FILE=uv.toml uv python install` downloads
+a managed interpreter; pin one for the project with
+`UV_CONFIG_FILE=uv.toml uv python pin 3.12` (writes `.python-version`). If uv itself
+errors with “required-version”, upgrade uv: the template requires uv >= 0.9.
 
 ## BasedPyright Erupts with Hundreds of Errors on Legacy Code
 
@@ -62,7 +63,7 @@ commit or stash first.
 The project predates the `publish_to_pypi` and `package_license` questions and the
 update filled them with defaults.
 Re-run the update passing the project’s reality, e.g.
-`uvx --exclude-newer "14 days" copier@9.16.0 update --data publish_to_pypi=false`, and
+`uvx --exclude-newer "14 days" copier@9.17.0 update --data publish_to_pypi=false`, and
 see “Reconciling New Questions on Update” in [customize.md](customize.md).
 
 ## Publish Workflow Fails with OIDC or Permission Errors
@@ -82,7 +83,7 @@ resolution differences.
 ## Tests Pass Locally but CI Fails on a Python Version
 
 The CI matrix runs 3.11–3.14. Most failures are version-specific syntax/stdlib use; run
-the failing version locally with `uv run --python 3.11 pytest`.
+the failing version locally with `UV_CONFIG_FILE=uv.toml uv run --python 3.11 pytest`.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -74,11 +74,14 @@ Follow `docs/publishing.md` in the project; no API tokens are needed.
 
 ## Lockfile Resolution Seems Stale or Refuses a Brand-New Release
 
-`UV_EXCLUDE_NEWER` (set in the template’s CI) enforces a 14-day supply-chain cooling-off
-window, so releases newer than that are deliberately invisible.
-This is a feature; don’t remove it to get a day-old package.
-Locally, leave the variable unset for normal work, or set it to match CI when debugging
-resolution differences.
+The checked-in `uv.toml` sets a 14-day supply-chain cooling-off window, so releases
+newer than that are deliberately invisible.
+The Makefile and CI select that file with `UV_CONFIG_FILE`; CI also sets the equivalent
+`UV_EXCLUDE_NEWER` value.
+This is a feature; don’t remove it to get a day-old package or let ambient user settings
+change the lock. Use the project’s standard commands when debugging resolution
+differences; make any reviewed exception an explicit, documented per-invocation
+override.
 
 ## Tests Pass Locally but CI Fails on a Python Version
 

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -31,7 +31,8 @@ No git tag yet: dynamic versioning derives the version from the latest `v*` tag.
 The template requires Python 3.11+. `UV_CONFIG_FILE=uv.toml uv python install` downloads
 a managed interpreter; pin one for the project with
 `UV_CONFIG_FILE=uv.toml uv python pin 3.12` (writes `.python-version`). If uv itself
-errors with “required-version”, upgrade uv: the template requires uv >= 0.9.
+errors with “required-version”, upgrade uv: the template supports the reviewed uv 0.12
+line (`>=0.12.0,<0.13`), matching its pinned CI toolchain.
 
 ## BasedPyright Erupts with Hundreds of Errors on Legacy Code
 

--- a/skills/simple-modern-uv/references/faq.md
+++ b/skills/simple-modern-uv/references/faq.md
@@ -33,6 +33,17 @@ a managed interpreter; pin one for the project with
 `UV_CONFIG_FILE=uv.toml uv python pin 3.12` (writes `.python-version`). If uv itself
 errors with “required-version”, upgrade uv: the template supports the reviewed uv 0.12
 line (`>=0.12.0,<0.13`), matching its pinned CI toolchain.
+Versions older than uv 0.9.17 may instead fail while parsing the relative duration
+`"14 days"`, before they can report the project’s required version.
+Treat that parse error the same way and upgrade uv first.
+
+## Ruff Rewrites Python Blocks in Markdown
+
+Ruff 0.16 and later include Markdown by default and can format Python code fences.
+The template gives Flowmark ownership of Markdown and sets
+`[tool.ruff] extend-exclude = ["*.md"]` so the tools do not compete.
+Add that setting when updating a project that adopted Ruff separately or predates this
+template policy.
 
 ## BasedPyright Erupts with Hundreds of Errors on Legacy Code
 

--- a/skills/simple-modern-uv/references/start-new-project.md
+++ b/skills/simple-modern-uv/references/start-new-project.md
@@ -1,0 +1,56 @@
+# Starting a New Project
+
+Create a new, fully template-managed Python project.
+
+## Gather and Confirm the Answers
+
+Use the interview contract in `SKILL.md`. Infer author name, email, and GitHub
+organization from git and GitHub state, then confirm the package name, derived module,
+description, license, publishing choice, and inferred identity in one message.
+
+## Render the Project
+
+Replace the example values and omit keys that should keep their defaults:
+
+```bash
+uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
+  --data package_name=acme-widgets \
+  --data "package_description=One-line description" \
+  --data "package_author_name=Jane Doe" \
+  --data package_author_email=jane@example.com \
+  --data package_github_org=acme \
+  --data package_license=MIT \
+  --data publish_to_pypi=true \
+  gh:jlevy/simple-modern-uv acme-widgets
+```
+
+`package_module` derives automatically from `package_name`.
+
+## Initialize and Install
+
+Commit before the first sync so dynamic versioning sees a real git history instead of
+installing the editable project as version `0.0.0`:
+
+```bash
+cd acme-widgets
+git init --initial-branch=main
+git add .
+git commit -m "Initial commit from simple-modern-uv."
+make install
+git add uv.lock
+git commit -m "Add uv.lock."
+```
+
+## Verify and Hand Off
+
+Run `make lint` and `make test`. For a publishable package, also run `make build` and
+confirm the wheel has a sensible development version.
+
+Offer the next useful steps: fill in `README.md`, create and push to an empty GitHub
+repository, configure the PyPI Trusted Publisher if applicable, and tag `v0.1.0` when
+the first release is ready.
+Report the result as full template-managed adoption.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/skills/simple-modern-uv/references/start-new-project.md
+++ b/skills/simple-modern-uv/references/start-new-project.md
@@ -4,9 +4,10 @@ Create a new, fully template-managed Python project.
 
 ## Gather and Confirm the Answers
 
-Use the interview contract in `SKILL.md`. Infer author name, email, and GitHub
-organization from git and GitHub state, then confirm the package name, derived module,
-description, license, publishing choice, and inferred identity in one message.
+Use the interview contract in [SKILL.md](../SKILL.md).
+Infer author name, email, and GitHub organization from git and GitHub state, then
+confirm the package name, derived module, description, license, publishing choice, and
+inferred identity in one message.
 
 ## Render the Project
 

--- a/skills/simple-modern-uv/references/update-templated-project.md
+++ b/skills/simple-modern-uv/references/update-templated-project.md
@@ -29,6 +29,10 @@ Inspect the complete diff.
 Resolve every `*.rej` file and conflict marker while preserving the project’s intent.
 Check the template release notes, but treat the actual rendered diff as the change under
 review.
+Once the update supplies `uv.toml` and explicit `UV_CONFIG_FILE` settings, remove
+any legacy `UV_NO_CONFIG` environment variables or command wrappers.
+Those workarounds disable the project policy that now owns the required uv version and
+cooling-off window.
 
 ## Verify and Report
 

--- a/skills/simple-modern-uv/references/update-templated-project.md
+++ b/skills/simple-modern-uv/references/update-templated-project.md
@@ -1,0 +1,46 @@
+# Updating a Template-Managed Project
+
+Use this workflow only when the project contains `.copier-answers.yml` from
+simple-modern-uv. If it does not, choose selective adoption or full migration instead of
+inventing template lineage.
+
+## Inspect Before Updating
+
+Require a clean working tree and work on a branch.
+Read `.copier-answers.yml`, inspect the project’s actual license and publishing state,
+and compare its answer keys with the current `copier.yml`.
+
+When the template has questions the project has never answered, pass explicit `--data`
+values matching the project’s existing behavior.
+Defaults describe a fresh project and must not silently re-license a package or restore
+a deliberately removed publish workflow.
+See `customize.md` for the reconciliation rules.
+
+## Apply the Update
+
+```bash
+uvx --exclude-newer "14 days" copier@9.17.0 update --defaults --skip-answered
+```
+
+Add reviewed `--data key=value` arguments for missing answers or intentional changes.
+Use a specific `--vcs-ref` when the user requests a pinned template release.
+
+Inspect the complete diff.
+Resolve every `*.rej` file and conflict marker while preserving the project’s intent.
+Check the template release notes, but treat the actual rendered diff as the change under
+review.
+
+## Verify and Report
+
+Run `make install`, `make lint`, and `make test`; for publishable projects, also run
+`make build`. Validate any changed workflow YAML and confirm `.copier-answers.yml`
+records the intended template revision and answers.
+
+Report upstream changes adopted unchanged, local adaptations retained, relevant features
+deferred, and superseded files removed.
+The result remains full template-managed even when documented project-specific
+deviations are preserved.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/skills/simple-modern-uv/references/update-templated-project.md
+++ b/skills/simple-modern-uv/references/update-templated-project.md
@@ -14,7 +14,7 @@ When the template has questions the project has never answered, pass explicit `-
 values matching the project’s existing behavior.
 Defaults describe a fresh project and must not silently re-license a package or restore
 a deliberately removed publish workflow.
-See `customize.md` for the reconciliation rules.
+See [customize.md](customize.md) for the reconciliation rules.
 
 ## Apply the Update
 

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ env:
   # make uv.lock appear stale or alter dependency selection.
   UV_CONFIG_FILE: uv.toml
   # Supply-chain cool-off: only consider releases older than this, so CI never
-  # resolves packages too new to have been vetted. uv (>= 0.9, and the version
-  # pinned below) accepts a relative duration directly. See the Supply Chain
-  # Hardening section in docs/development.md.
+  # resolves packages too new to have been vetted. The uv 0.12 line required by
+  # uv.toml and pinned below accepts a relative duration directly. See the Supply
+  # Chain Hardening section in docs/development.md.
   UV_EXCLUDE_NEWER: "14 days"
 
 jobs:

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ permissions:
   contents: read
 
 env:
+  # Use only the checked-in resolution policy so ambient runner configuration cannot
+  # make uv.lock appear stale or alter dependency selection.
+  UV_CONFIG_FILE: uv.toml
   # Supply-chain cool-off: only consider releases older than this, so CI never
   # resolves packages too new to have been vetted. uv (>= 0.9, and the version
   # pinned below) accepts a relative duration directly. See the Supply Chain
@@ -40,7 +43,7 @@ jobs:
       - name: Checkout (official GitHub action)
         # Pinned to a full commit SHA (see supply-chain notes in
         # docs/development.md); bump deliberately when updating.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Important for versioning plugins:
           fetch-depth: 0
@@ -49,13 +52,16 @@ jobs:
       - name: Install uv (official Astral action)
         # Pinned to a full commit SHA. Bump the action, uv version, and Linux
         # checksum together when updating.
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           # Update this as needed:
-          version: "0.11.25"
+          version: "0.12.0"
           # uv-x86_64-unknown-linux-gnu; update for another matrix OS/arch.
-          checksum: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
+          checksum: "eaf842262aa1c418d8ecc5605f02ee1ebfd369124fa48548e85f9481a47831a9"
           enable-cache: true
+          # Retain downloaded wheels in the shared cache to reduce PyPI load.
+          # This is setup-uv v9's default, made explicit for future upgrades.
+          prune-cache: false
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Python (using uv)
@@ -69,9 +75,9 @@ jobs:
       #     python-version: ${{ matrix.python-version }}
 
       - name: Install all dependencies
-        # --frozen: install exactly from the committed uv.lock, never re-resolving
-        # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen).
-        run: uv sync --all-extras --all-groups --frozen
+        # --locked: install from uv.lock and fail if pyproject.toml made it stale.
+        # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen.)
+        run: uv sync --locked --all-extras --all-groups
 
       - name: Run linting
         # Check-only mode so CI fails on unformatted code instead of fixing it.

--- a/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
+++ b/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
@@ -10,9 +10,9 @@ env:
   # make uv.lock appear stale or alter dependency selection.
   UV_CONFIG_FILE: uv.toml
   # Supply-chain cool-off: only consider releases older than this, so the publish
-  # build never resolves packages too new to have been vetted. uv (>= 0.9, and the
-  # version pinned below) accepts a relative duration directly. See the Supply Chain
-  # Hardening section in docs/development.md.
+  # build never resolves packages too new to have been vetted. The uv 0.12 line
+  # required by uv.toml and pinned below accepts a relative duration directly. See the
+  # Supply Chain Hardening section in docs/development.md.
   UV_EXCLUDE_NEWER: "14 days"
 
 jobs:

--- a/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
+++ b/template/.github/workflows/{% if publish_to_pypi %}publish.yml{% endif %}
@@ -6,6 +6,9 @@ on:
   workflow_dispatch: # Enable manual trigger.
 
 env:
+  # Use only the checked-in resolution policy so ambient runner configuration cannot
+  # make uv.lock appear stale or alter dependency selection.
+  UV_CONFIG_FILE: uv.toml
   # Supply-chain cool-off: only consider releases older than this, so the publish
   # build never resolves packages too new to have been vetted. uv (>= 0.9, and the
   # version pinned below) accepts a relative duration directly. See the Supply Chain
@@ -22,7 +25,7 @@ jobs:
       - name: Checkout (official GitHub action)
         # Pinned to a full commit SHA (see supply-chain notes in
         # docs/development.md); bump deliberately when updating.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Important for versioning plugins:
           fetch-depth: 0
@@ -30,21 +33,23 @@ jobs:
 
       - name: Install uv (official Astral action)
         # Pinned to a full commit SHA (see note in ci.yml).
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "0.11.25"
+          version: "0.12.0"
           # uv-x86_64-unknown-linux-gnu.
-          checksum: "1db18b5e76fa645a7f3865773139bdec8e2d46adbdbb35e7410b34fa8015ccd2"
-          enable-cache: true
+          checksum: "eaf842262aa1c418d8ecc5605f02ee1ebfd369124fa48548e85f9481a47831a9"
+          # Release workflows do not restore or save shared caches, reducing
+          # cache-poisoning exposure in this privileged OIDC job.
+          enable-cache: false
           python-version: "3.12"
 
       - name: Set up Python (using uv)
         run: uv python install
 
       - name: Install all dependencies
-        # --frozen: install exactly from the committed uv.lock, never re-resolving
-        # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen).
-        run: uv sync --all-extras --all-groups --frozen
+        # --locked: install from uv.lock and fail if pyproject.toml made it stale.
+        # (UV_EXCLUDE_NEWER, set above, governs any resolution that does happen.)
+        run: uv sync --locked --all-extras --all-groups
 
       - name: Run tests
         run: uv run pytest

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -40,15 +40,27 @@ Or call uv directly with the checked-in configuration:
 
 - **Versioning**: the version comes from git tags via dynamic versioning; never edit a
   version number in `pyproject.toml`.
-  {%- if publish_to_pypi %} Releases are published to PyPI by tagging `vX.Y.Z` (see
+  {%- if publish_to_pypi %}
+
+- **Publishing**: releases are published to PyPI by tagging `vX.Y.Z` (see
   `docs/publishing.md`).
   {%- endif %}
 
-- This project was built from the
-  [simple-modern-uv](https://github.com/jlevy/simple-modern-uv) template; pull future
-  template improvements with `copier update`.
-
 See [docs/development.md](docs/development.md) for full developer workflows.
+
+## Template Maintenance
+
+This project was built from
+[simple-modern-uv](https://github.com/jlevy/simple-modern-uv).
+Routine project work uses the instructions above; do not fetch the upstream template for
+every task.
+
+For toolchain changes, selective adoption of another template feature, or a Copier
+update, use the portable
+[simple-modern-uv skill](https://github.com/jlevy/simple-modern-uv/tree/main/skills/simple-modern-uv).
+It preserves project-specific choices and distinguishes selective changes from full
+template management.
+`.copier-answers.yml` records this project’s update lineage.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -1,9 +1,9 @@
 # Project Instructions for AI Agents
 
-Instructions for AI coding agents working on {{ package_name }}. (This file follows the
+Instructions for AI coding agents working on {{ package_name }}. This file follows the
 [AGENTS.md](https://agents.md) convention.
-Claude Code reads `CLAUDE.md` instead, which imports this file via its `@AGENTS.md`
-line, so edits here reach every agent.)
+Claude Code reads `CLAUDE.md`, which imports this file through its `@AGENTS.md` line, so
+both instruction paths stay aligned.
 
 ## Build and Test
 
@@ -15,7 +15,7 @@ make install     # uv sync --all-extras --all-groups (install all deps into .ven
 make lint        # auto-format and lint: codespell, ruff check --fix, ruff format, basedpyright
 make lint-check  # check-only variant, matching CI (fails instead of fixing)
 make test        # uv run pytest
-make build       # locked, non-isolated uv build (wheel + sdist)
+make build       # locked, non-isolated uv build (wheel and sdist)
 ```
 
 Or call uv directly with the checked-in configuration:

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -18,9 +18,10 @@ make test        # uv run pytest
 make build       # locked, non-isolated uv build (wheel + sdist)
 ```
 
-Or call uv directly: `uv run pytest tests/test_foo.py`,
-`uv add --exclude-newer "14 days" some-package`, or
-`uv run python -m {{ package_module }}`.
+Or call uv directly with the checked-in configuration:
+`UV_CONFIG_FILE=uv.toml uv run pytest tests/test_foo.py`,
+`UV_CONFIG_FILE=uv.toml uv add --exclude-newer "14 days" some-package`, or
+`UV_CONFIG_FILE=uv.toml uv run python -m {{ package_module }}`.
 
 ## Conventions
 
@@ -29,11 +30,12 @@ Or call uv directly: `uv run pytest tests/test_foo.py`,
 - **Python**: 3.11+ only; use modern typing (full annotations, no `from __future__`).
 
 - **Lint/format**: ruff (line length 100) plus codespell; type checking is
-  [basedpyright](https://docs.basedpyright.com/). Settings live in `pyproject.toml`. Run
-  `make lint` before committing.
+  [basedpyright](https://docs.basedpyright.com/). Tool settings live in
+  `pyproject.toml`; project-owned uv settings live in `uv.toml`. Run `make lint` before
+  committing.
 
-- **Dependencies**: add with `uv add --exclude-newer "14 days"` (runtime) or
-  `uv add --dev --exclude-newer "14 days"` (dev).
+- **Dependencies**: add with `UV_CONFIG_FILE=uv.toml uv add --exclude-newer "14 days"`
+  (runtime) or `UV_CONFIG_FILE=uv.toml uv add --dev --exclude-newer "14 days"` (dev).
   Commit `uv.lock`. Don’t use pip, poetry, or requirements.txt.
 
 - **Versioning**: the version comes from git tags via dynamic versioning; never edit a

--- a/template/Makefile
+++ b/template/Makefile
@@ -4,6 +4,11 @@
 
 .DEFAULT_GOAL := default
 
+# Use only the checked-in project configuration. Otherwise uv merges user- and
+# system-level settings into uv.lock, which can make it fail on another machine.
+UV_CONFIG_FILE := $(CURDIR)/uv.toml
+export UV_CONFIG_FILE
+
 # Safe default for every dependency resolution invoked through this Makefile.
 UV_EXCLUDE_NEWER ?= 14 days
 export UV_EXCLUDE_NEWER

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -8,6 +8,20 @@ project.\]\]\]
 
 * * *
 
+## Working With a Coding Agent
+
+This repository includes [`AGENTS.md`](AGENTS.md), with the build, test, dependency,
+layout, and release conventions a coding agent needs for routine work.
+`CLAUDE.md` imports the same instructions for Claude Code.
+
+For an ordinary change, tell your agent: “Read `AGENTS.md`, implement this change, and
+run the required checks.”
+For toolchain or template maintenance, ask it to use the
+[simple-modern-uv skill](https://github.com/jlevy/simple-modern-uv/tree/main/skills/simple-modern-uv),
+which distinguishes selective feature adoption from a full Copier update.
+
+* * *
+
 ## Project Docs
 
 For how to install uv and Python, see [installation.md](docs/installation.md).

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,14 +1,13 @@
 # {{ package_name }}
 
-👉\[\[\[**This is the initial readme for your
-[simple-modern-uv](https://github.com/jlevy/simple-modern-uv) template.** Fill it in and
-delete this message!
-Below are general setup instructions that you may remove or keep and adapt for your
-project.\]\]\]
+> ⚠️ **This is the initial README for your
+> [simple-modern-uv](https://github.com/jlevy/simple-modern-uv) project.** Fill it in
+> and delete this message.
+> Keep or adapt the general setup instructions below as needed.
 
 * * *
 
-## Working With a Coding Agent
+## Working with a Coding Agent
 
 This repository includes [`AGENTS.md`](AGENTS.md), with the build, test, dependency,
 layout, and release conventions a coding agent needs for routine work.

--- a/template/docs/development.md.jinja
+++ b/template/docs/development.md.jinja
@@ -21,10 +21,6 @@ The `Makefile` simply offers shortcuts to `uv` commands for developer convenienc
 # dependency resolution or make uv.lock nonportable. The Makefile does this itself.
 export UV_CONFIG_FILE="$PWD/uv.toml"
 
-# Apply the supply-chain cool-off to direct uv commands below. The Makefile sets the
-# same default for its recipes; override the variable explicitly if needed.
-export UV_EXCLUDE_NEWER="14 days"
-
 # First, install all dependencies and set up your virtual environment.
 # This runs `uv sync --all-extras --all-groups` to install runtime, development,
 # optional, and locked build dependencies.
@@ -33,7 +29,7 @@ make install
 # Run uv sync, lint, and test:
 make
 
-# Build wheel:
+# Build the wheel and source distribution:
 make build
 
 # Linting (auto-fixes formatting and lint issues):
@@ -53,7 +49,7 @@ make upgrade
 
 # To run tests by hand:
 uv run pytest   # all tests
-uv run pytest -s src/module/some_file.py  # one test, showing outputs
+uv run pytest -s tests/test_placeholder.py  # one test file, showing output
 
 # Build and install current dev executables, to let you use your dev copies
 # as local tools:
@@ -76,7 +72,7 @@ source .venv/bin/activate
 
 See [uv docs](https://docs.astral.sh/uv/) for details.
 
-## IDE setup
+## IDE Setup
 
 If you use VSCode or a fork like Cursor or Windsurf, you can install the following
 extensions:
@@ -97,11 +93,12 @@ Its key defaults:
 
 - **Cool-off period:** Don’t install or upgrade to a release less than 14 days old
   (absent a documented exception); most malicious publishes are caught within days.
-  For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this project sets it in `uv.toml`, CI, and the Makefile so
-  direct commands and standard workflows default to the same policy.
-  The Makefile and examples select `uv.toml` explicitly so user- or system-level uv
-  settings cannot leak into the committed lockfile.
+  uv supports a relative
+  [dependency cooldown](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns)
+  such as `"14 days"`. This project records the policy in `uv.toml`; the Makefile, CI,
+  and examples select that file explicitly so user- or system-level
+  [uv configuration](https://docs.astral.sh/uv/configuration/files/) cannot leak into
+  the committed lockfile.
   Override it explicitly for a stricter window, such as
   `UV_EXCLUDE_NEWER="30 days" make upgrade`. A reviewed emergency exception must be
   equally explicit, using `UV_EXCLUDE_NEWER="0 days"` only for that invocation and

--- a/template/docs/development.md.jinja
+++ b/template/docs/development.md.jinja
@@ -17,8 +17,12 @@ The `Makefile` simply offers shortcuts to `uv` commands for developer convenienc
 (For clarity, GitHub Actions don’t use the Makefile and just call `uv` directly.)
 
 ```shell
-# Apply the supply-chain cool-off to direct uv commands below. The Makefile sets
-# the same default for its recipes; override the variable explicitly if needed.
+# Select only the checked-in uv settings so ambient user configuration cannot alter
+# dependency resolution or make uv.lock nonportable. The Makefile does this itself.
+export UV_CONFIG_FILE="$PWD/uv.toml"
+
+# Apply the supply-chain cool-off to direct uv commands below. The Makefile sets the
+# same default for its recipes; override the variable explicitly if needed.
 export UV_EXCLUDE_NEWER="14 days"
 
 # First, install all dependencies and set up your virtual environment.
@@ -94,8 +98,10 @@ Its key defaults:
 - **Cool-off period:** Don’t install or upgrade to a release less than 14 days old
   (absent a documented exception); most malicious publishes are caught within days.
   For uv, set `UV_EXCLUDE_NEWER` to a cool-off window (recent uv accepts a relative
-  duration like `"14 days"`); this project sets it in `pyproject.toml`, CI, and the
-  Makefile so direct commands and standard workflows default to the same policy.
+  duration like `"14 days"`); this project sets it in `uv.toml`, CI, and the Makefile so
+  direct commands and standard workflows default to the same policy.
+  The Makefile and examples select `uv.toml` explicitly so user- or system-level uv
+  settings cannot leak into the committed lockfile.
   Override it explicitly for a stricter window, such as
   `UV_EXCLUDE_NEWER="30 days" make upgrade`. A reviewed emergency exception must be
   equally explicit, using `UV_EXCLUDE_NEWER="0 days"` only for that invocation and

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -106,6 +106,8 @@ packages = ["src/{{ package_module }}"]
 [tool.ruff]
 # Set as desired, typically 88 (black standard) or 100 (wide).
 line-length = 100
+# Flowmark owns Markdown formatting; Ruff owns Python source formatting.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = [

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -15,7 +15,7 @@ readme = "README.md"
 {%- if package_license == 'None' %}
 # No license chosen yet. When you pick one, set an SPDX expression here and add a
 # LICENSE file, or re-answer the template question:
-# uvx --exclude-newer "14 days" copier@9.16.0 update --data package_license=MIT
+# uvx --exclude-newer "14 days" copier@9.17.0 update --data package_license=MIT
 {%- else %}
 license = "{{ 'LicenseRef-Proprietary' if package_license == 'Proprietary' else package_license }}"
 {%- endif %}
@@ -58,14 +58,14 @@ dependencies = [
 
 [dependency-groups]
 build = [
-    "hatchling==1.30.1",
+    "hatchling==1.31.0",
     "uv-dynamic-versioning==0.14.0",
 ]
 dev = [
     "pytest>=9.1.1",
     "pytest-sugar>=1.1.1",
-    "ruff>=0.15.20",
-    "codespell>=2.4.2",
+    "ruff>=0.16.1",
+    "codespell>=2.4.3",
     "rich>=15.0.0",
     "basedpyright>=1.39.9",
     "funlog>=0.2.1",
@@ -82,7 +82,7 @@ dev = [
 # https://github.com/ninoseki/uv-dynamic-versioning/
 
 [build-system]
-requires = ["hatchling==1.30.1", "uv-dynamic-versioning==0.14.0"]
+requires = ["hatchling==1.31.0", "uv-dynamic-versioning==0.14.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -101,15 +101,7 @@ bump = true
 packages = ["src/{{ package_module }}"]
 
 
-# ---- Settings ----
-
-[tool.uv]
-# Fail fast on old uv versions rather than misbehave. 0.9 is the floor where
-# exclude-newer accepts a relative duration like "14 days".
-required-version = ">=0.9"
-# Safe project-level default for every uv command. CI and the Makefile repeat it so
-# copied commands and tool execution outside project discovery retain the same policy.
-exclude-newer = "14 days"
+# ---- Tool Settings ----
 
 [tool.ruff]
 # Set as desired, typically 88 (black standard) or 100 (wide).

--- a/template/uv.toml
+++ b/template/uv.toml
@@ -1,0 +1,4 @@
+# Keep resolution-affecting settings project-owned. The Makefile and CI select this
+# file explicitly so user- or system-level uv settings cannot make uv.lock nonportable.
+required-version = ">=0.9"
+exclude-newer = "14 days"

--- a/template/uv.toml
+++ b/template/uv.toml
@@ -1,4 +1,4 @@
 # Keep resolution-affecting settings project-owned. The Makefile and CI select this
 # file explicitly so user- or system-level uv settings cannot make uv.lock nonportable.
-required-version = ">=0.9"
+required-version = ">=0.12.0,<0.13"
 exclude-newer = "14 days"

--- a/updating.md
+++ b/updating.md
@@ -1,6 +1,6 @@
 # Updating This Template
 
-This doc covers the full cycle for keeping the
+Use this process to keep the
 [simple-modern-uv](https://github.com/jlevy/simple-modern-uv) template’s dependencies
 and tools up to date, then verifying the changes end-to-end.
 
@@ -26,8 +26,8 @@ The commands below assume the downstream repo is cloned next to this repo as
 `../simple-modern-uv-template`.
 
 **Releasing without downstream access** (for example, an agent session scoped to this
-repo only): this repo’s CI on the candidate commit is the gate — all jobs must be green
-— plus a local render verification (Step 5 run against a fresh render).
+repo only): this repo’s CI on the candidate commit is the gate—all jobs must be
+green—plus a local render verification (Step 5 run against a fresh render).
 Create the release on that basis, then complete the downstream export and tag recording
 (Steps 4–6 and 8) as post-release verification from an environment with access.
 If downstream then fails, fix forward with a patch release.
@@ -184,8 +184,8 @@ In the template repo, update these files as needed:
 - **The project-level uv policy**: keep `exclude-newer = "14 days"` in `uv.toml` and
   select that file explicitly in the Makefile and CI, so direct standard workflows keep
   the cool-off without merging ambient user settings into `uv.lock`
-- Review `docs/project/research/research-uv-changes.md` for new uv features the template
-  should adopt or explicitly decline
+- Review the [uv changes research](docs/project/research/research-uv-changes.md) for new
+  uv features the template should adopt or explicitly decline
 - Record the complete frozen decision in a release-specific supply-chain manifest under
   `docs/project/research/`
 
@@ -201,7 +201,7 @@ projects keep updating cleanly:
    `--defaults --skip-answered` fills new keys.
 3. **Hand customizations are reconciled by the skill**, not by defaults: the skill’s
    update workflow inspects project state and passes explicit `--data` (see
-   `skills/simple-modern-uv/references/customize.md`).
+   [customize.md](skills/simple-modern-uv/references/customize.md)).
 4. **CI guards the update path**: the `update-path` job renders the previous release and
    updates to the candidate, asserting convergence with a fresh render and that `--data`
    overrides are honored.

--- a/updating.md
+++ b/updating.md
@@ -41,7 +41,12 @@ A merge followed immediately by a tag skips that gate, the reviewed release note
 verification that the public tag reproduces the validated commit.
 
 The commands below assume the downstream repo is cloned next to this repo as
-`../simple-modern-uv-template`.
+`../simple-modern-uv-template`. They also require a GitHub CLI release whose
+`gh run list` command supports `--commit`. Check that capability before starting:
+
+```shell
+gh run list --help | grep -q -- '--commit'
+```
 
 ### Releasing Without Downstream Access
 
@@ -225,6 +230,11 @@ projects keep updating cleanly:
    updates to the candidate, asserting convergence with a fresh render and that `--data`
    overrides are honored.
 5. **Call it out in release notes**, naming the new keys and their defaults.
+
+The update-path job guarantees the single jump from the most recent release to the
+candidate. For a project more than one release behind, update one release tag at a time
+and validate each hop; a direct multi-release jump is best-effort rather than covered by
+this gate.
 
 Then auto-format all docs so formatting stays consistent (CI’s `format-check` job
 enforces this):

--- a/updating.md
+++ b/updating.md
@@ -181,8 +181,9 @@ In the template repo, update these files as needed:
   `before` cutoff, disable lifecycle scripts, and record registry integrity/provenance
 - **Safe-default Makefile paths**: keep the 14-day default on install, upgrade, format,
   and build commands, while preserving an explicit per-invocation override
-- **The project-level uv policy**: keep `tool.uv.exclude-newer = "14 days"` so direct uv
-  commands cannot silently omit the cool-off
+- **The project-level uv policy**: keep `exclude-newer = "14 days"` in `uv.toml` and
+  select that file explicitly in the Makefile and CI, so direct standard workflows keep
+  the cool-off without merging ambient user settings into `uv.lock`
 - Review `docs/project/research/research-uv-changes.md` for new uv features the template
   should adopt or explicitly decline
 - Record the complete frozen decision in a release-specific supply-chain manifest under
@@ -214,7 +215,7 @@ make format        # auto-format all Markdown docs, including *.md.jinja templat
 make format-check  # check-only, to confirm nothing is left unformatted
 ```
 
-This runs the pinned `uvx flowmark-rs@0.3.1 --auto` from the top-level `Makefile`, which
+This runs the pinned `uvx flowmark-rs@0.3.2 --auto` from the top-level `Makefile`, which
 also applies the 14-day resolver gate by default.
 
 ## Step 3: Commit and Push the Template Candidate
@@ -242,7 +243,7 @@ git status --short
 
 # Export the exact template candidate. This uses the _src_path already recorded in
 # .copier-answers.yml, currently gh:jlevy/simple-modern-uv.
-uvx --exclude-newer "14 days" copier@9.16.0 update --defaults \
+uvx --exclude-newer "14 days" copier@9.17.0 update --defaults \
   --vcs-ref "$TEMPLATE_COMMIT"
 git diff --stat
 ```
@@ -251,7 +252,7 @@ If the downstream repo ever needs a fresh render instead of an update, instantia
 the standard defaults:
 
 ```shell
-uvx --exclude-newer "14 days" copier@9.16.0 copy --defaults \
+uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
   --vcs-ref "$TEMPLATE_COMMIT" gh:jlevy/simple-modern-uv .
 ```
 
@@ -265,7 +266,7 @@ make install
 make lint-check
 make test
 make build
-uvx --exclude-newer "14 days" uv@0.11.25 audit --locked \
+uvx --exclude-newer "14 days" uv@0.12.0 audit --locked \
   --preview-features audit-command
 ```
 
@@ -312,11 +313,11 @@ create a GitHub release on the template repo.
 
 Pick the version by what changed:
 
-- **Minor** (`v0.4.0`): new or changed template questions, new files or dependency
+- **Minor** (`v0.5.0`): new or changed template questions, new files or dependency
   groups in the render, or other feature-level changes.
   Per the answer-schema policy above, the release notes must name any new question keys
   and their defaults.
-- **Patch** (`v0.3.1`): routine dependency and tool-version bumps, doc fixes, and
+- **Patch** (`v0.4.1`): routine dependency and tool-version bumps, doc fixes, and
   changes that leave the render’s shape alone.
 
 Review the changes and author the release notes as a file first (the gitignored `tmp/`
@@ -350,7 +351,7 @@ a statement of what validation backed the release, and the
 
 Afterwards, verify the release: the tag points at `$TEMPLATE_COMMIT`
 (`gh release view "$NEW_TAG" --json tagName,targetCommitish,isDraft`) and a fresh
-`uvx --exclude-newer "14 days" copier@9.16.0 copy gh:jlevy/simple-modern-uv` records the
+`uvx --exclude-newer "14 days" copier@9.17.0 copy gh:jlevy/simple-modern-uv` records the
 new tag as `_commit` in `.copier-answers.yml`.
 
 ## Step 8: Record the Release Tag Downstream
@@ -362,7 +363,7 @@ This should either be a no-op or only change `_commit`.
 
 ```shell
 cd ../simple-modern-uv-template
-uvx --exclude-newer "14 days" copier@9.16.0 update --defaults \
+uvx --exclude-newer "14 days" copier@9.17.0 update --defaults \
   --vcs-ref "$NEW_TAG"
 git diff -- .copier-answers.yml
 

--- a/updating.md
+++ b/updating.md
@@ -2,7 +2,7 @@
 
 Use this process to keep the
 [simple-modern-uv](https://github.com/jlevy/simple-modern-uv) template’s dependencies
-and tools up to date, then verifying the changes end-to-end.
+and tools up to date, then verify the changes end-to-end.
 
 There are two repos involved:
 
@@ -19,18 +19,37 @@ There are two repos involved:
   The downstream repo remains the **release gate** (full matrix, real `copier update`
   against a long-lived project).
 
-Release rule: the downstream repo is the release gate when it is reachable.
-Push the template candidate, export it into `jlevy/simple-modern-uv-template`, and wait
-for downstream CI to pass before creating a GitHub release for this template.
+## Release Sequence
+
+A normal release has five stages:
+
+1. **Finish the candidate PR:** Resolve known release blockers, freeze the dependency
+   evidence, and require every template-repo CI job to pass.
+2. **Merge and identify the candidate:** Merge the PR into `main`, record its exact
+   merge commit as `TEMPLATE_COMMIT`, and require that commit’s `main` CI run to pass.
+3. **Pass the downstream gate:** Update `jlevy/simple-modern-uv-template` from that
+   exact commit, verify it locally, merge the downstream validation PR, and require its
+   full Python matrix to pass.
+4. **Publish the template release:** Create a GitHub Release targeting
+   `TEMPLATE_COMMIT`. GitHub creates the version tag as part of this action; do not
+   create or push a bare tag separately.
+5. **Record the public tag downstream:** Update the downstream project from the new tag
+   and merge the resulting `.copier-answers.yml` bookkeeping change.
+
+The downstream project is the release gate when it is reachable.
+A merge followed immediately by a tag skips that gate, the reviewed release notes, and
+verification that the public tag reproduces the validated commit.
+
 The commands below assume the downstream repo is cloned next to this repo as
 `../simple-modern-uv-template`.
 
-**Releasing without downstream access** (for example, an agent session scoped to this
-repo only): this repo’s CI on the candidate commit is the gate—all jobs must be
-green—plus a local render verification (Step 5 run against a fresh render).
-Create the release on that basis, then complete the downstream export and tag recording
-(Steps 4–6 and 8) as post-release verification from an environment with access.
-If downstream then fails, fix forward with a patch release.
+### Releasing Without Downstream Access
+
+When the downstream repo is not reachable, this repo’s CI on the candidate commit is the
+gate—all jobs must be green—plus a local render verification (Step 5 run against a fresh
+render). Create the release on that basis, then complete the downstream export and tag
+recording (Steps 4–6 and 8) as post-release verification from an environment with
+access. If downstream then fails, fix forward with a patch release.
 
 ## Step 1: Check Latest Versions
 
@@ -218,19 +237,59 @@ make format-check  # check-only, to confirm nothing is left unformatted
 This runs the pinned `uvx flowmark-rs@0.3.2 --auto` from the top-level `Makefile`, which
 also applies the 14-day resolver gate by default.
 
-## Step 3: Commit and Push the Template Candidate
+## Step 3: Merge the Template Candidate
 
-Commit the template changes and push `main`, but do not create the release yet.
-The downstream repo needs to export the exact candidate commit first.
+Choose the release version before downstream validation:
+
+- **Minor** (`v0.5.0`): new or changed template questions, new files or dependency
+  groups in the render, or other feature-level changes.
+  Per the answer-schema policy above, the release notes must name any new question keys
+  and their defaults.
+- **Patch** (`v0.4.1`): routine dependency and tool-version bumps, documentation fixes,
+  and changes that leave the render’s shape unchanged.
+
+Resolve every known release blocker and finish review on the candidate PR. Mark it ready
+for review, require its CI to pass, and merge it into `main`. Do not create the release
+or tag yet: downstream must validate the exact merge commit first.
 
 ```shell
-git add -A
-git commit -m "Update dependencies and tool versions."
-git push origin main
+CURRENT_BRANCH=$(git branch --show-current)
+PR_NUMBER=$(gh pr view "$CURRENT_BRANCH" --repo jlevy/simple-modern-uv \
+  --json number -q '.number')
+NEW_TAG="v0.X.Y"
+LAST_TAG=$(gh release list --repo jlevy/simple-modern-uv --limit 1 \
+  --json tagName -q '.[0].tagName')
 
-# Record the exact commit that downstream CI will validate:
-TEMPLATE_COMMIT=$(git rev-parse HEAD)
+if [ "$(gh pr view "$PR_NUMBER" --repo jlevy/simple-modern-uv \
+  --json isDraft -q '.isDraft')" = "true" ]; then
+  gh pr ready "$PR_NUMBER" --repo jlevy/simple-modern-uv
+fi
+gh pr checks "$PR_NUMBER" --repo jlevy/simple-modern-uv --watch
+gh pr merge "$PR_NUMBER" --repo jlevy/simple-modern-uv --merge
+
+TEMPLATE_COMMIT=$(gh pr view "$PR_NUMBER" --repo jlevy/simple-modern-uv \
+  --json mergeCommit -q '.mergeCommit.oid')
+git fetch origin main --tags
+test "$(git rev-parse origin/main)" = "$TEMPLATE_COMMIT"
+
+SOURCE_RUN_ID=$(gh run list \
+  --repo jlevy/simple-modern-uv \
+  --workflow CI \
+  --branch main \
+  --event push \
+  --commit "$TEMPLATE_COMMIT" \
+  --json databaseId \
+  -q '.[0].databaseId')
+test -n "$SOURCE_RUN_ID"
+gh run watch --repo jlevy/simple-modern-uv \
+  "$SOURCE_RUN_ID" --exit-status
 ```
+
+The final assertion stops the release if `main` moved after the candidate merged.
+Review the additional commits and select a new candidate rather than releasing an
+unvalidated tip.
+If GitHub has not queued the `main` run when `SOURCE_RUN_ID` is queried,
+wait for it to appear and repeat the query.
 
 ## Step 4: Export the Candidate to the Downstream Repo
 
@@ -239,7 +298,11 @@ The working tree must be clean before running `copier update`.
 
 ```shell
 cd ../simple-modern-uv-template
-git status --short
+git switch main
+git pull --ff-only origin main
+test -z "$(git status --porcelain)"
+DOWNSTREAM_BRANCH="validate-${NEW_TAG}-template"
+git switch -c "$DOWNSTREAM_BRANCH"
 
 # Export the exact template candidate. This uses the _src_path already recorded in
 # .copier-answers.yml, currently gh:jlevy/simple-modern-uv.
@@ -272,23 +335,42 @@ uvx --exclude-newer "14 days" uv@0.12.0 audit --locked \
 
 ## Step 6: Push Downstream and Confirm CI
 
-Commit and push the downstream project, then wait for GitHub Actions to finish.
+Commit the downstream candidate on its own branch, open a PR, and wait for GitHub
+Actions to finish before merging it.
 
 ```shell
 git add -A
 git commit -m "Validate simple-modern-uv template ${TEMPLATE_COMMIT:0:7}."
-git push origin main
+git push -u origin "$DOWNSTREAM_BRANCH"
 
+DOWNSTREAM_PR=$(gh pr create \
+  --repo jlevy/simple-modern-uv-template \
+  --base main \
+  --head "$DOWNSTREAM_BRANCH" \
+  --title "chore: validate ${NEW_TAG} template candidate" \
+  --body "Validates simple-modern-uv commit ${TEMPLATE_COMMIT} before release.")
+gh pr checks "$DOWNSTREAM_PR" --watch
+gh pr merge "$DOWNSTREAM_PR" --merge --delete-branch
+
+DOWNSTREAM_COMMIT=$(gh pr view "$DOWNSTREAM_PR" \
+  --repo jlevy/simple-modern-uv-template \
+  --json mergeCommit -q '.mergeCommit.oid')
 RUN_ID=$(gh run list \
   --repo jlevy/simple-modern-uv-template \
   --workflow CI \
   --branch main \
   --event push \
+  --commit "$DOWNSTREAM_COMMIT" \
   --json databaseId \
   -q '.[0].databaseId')
-
+test -n "$RUN_ID"
 gh run watch --repo jlevy/simple-modern-uv-template "$RUN_ID" --exit-status
 ```
+
+If GitHub has not queued the `main` run when `RUN_ID` is queried, wait for it to appear
+and repeat the query.
+The release gate is the successful `main` run for `DOWNSTREAM_COMMIT`, not only the PR’s
+pre-merge checks.
 
 Then check that **CI passes on GitHub**: this runs the full lint and test suite across
 all Python versions in the matrix (e.g. 3.11, 3.12, 3.13, 3.14) on the stub test file
@@ -308,17 +390,10 @@ at least one target agent (CI validates structure and links, not activation):
 
 ## Step 7: Create a Release on the Template Repo
 
-Once CI passes downstream (and this repo’s own CI is green on the candidate commit),
-create a GitHub release on the template repo.
-
-Pick the version by what changed:
-
-- **Minor** (`v0.5.0`): new or changed template questions, new files or dependency
-  groups in the render, or other feature-level changes.
-  Per the answer-schema policy above, the release notes must name any new question keys
-  and their defaults.
-- **Patch** (`v0.4.1`): routine dependency and tool-version bumps, doc fixes, and
-  changes that leave the render’s shape alone.
+Once CI passes downstream and this repo’s own CI is green on `TEMPLATE_COMMIT`, create a
+GitHub Release on the template repo.
+This command creates the version tag; do not run a separate `git tag` or
+`git push --tags` first.
 
 Review the changes and author the release notes as a file first (the gitignored `tmp/`
 directory is the convention; a file keeps the shell out of the way, since notes
@@ -328,11 +403,8 @@ routinely contain backticks and `$`):
 # From the template repo:
 cd ../simple-modern-uv
 
-LAST_TAG=$(gh release list --repo jlevy/simple-modern-uv --limit 1 --json tagName -q '.[0].tagName')
-NEW_TAG="v0.X.Y"
-
-git log "${LAST_TAG}..HEAD" --oneline
-git diff --stat "${LAST_TAG}..HEAD"
+git log "${LAST_TAG}..${TEMPLATE_COMMIT}" --oneline
+git diff --stat "${LAST_TAG}..${TEMPLATE_COMMIT}"
 
 # Write tmp/release-notes-${NEW_TAG}.md, then:
 gh release create "$NEW_TAG" \
@@ -342,17 +414,28 @@ gh release create "$NEW_TAG" \
   --notes-file "tmp/release-notes-${NEW_TAG}.md"
 ```
 
-Structure the notes per `tbd guidelines release-notes-guidelines` (or the same format
-the template’s own `docs/publishing.md` describes): a one-paragraph summary of the
-release’s theme, `### New Features` / `### Improvements` sections, an upgrading note for
-existing projects, new question keys with their defaults (per the answer-schema policy),
-a statement of what validation backed the release, and the
-`compare/${LAST_TAG}...${NEW_TAG}` link.
+Structure the notes per `tbd guidelines release-notes-guidelines`: a concise summary,
+then `## What's Changed` with only the applicable `### Features`, `### Fixes`,
+`### Guidelines and content`, and `### Documentation` sections.
+Add `## Upgrading` when existing projects need action.
+Name new question keys and defaults under upgrading, state what validation backed the
+release, and end with a `**Full commit history**` link to
+`compare/${LAST_TAG}...${NEW_TAG}`.
 
-Afterwards, verify the release: the tag points at `$TEMPLATE_COMMIT`
-(`gh release view "$NEW_TAG" --json tagName,targetCommitish,isDraft`) and a fresh
-`uvx --exclude-newer "14 days" copier@9.17.0 copy gh:jlevy/simple-modern-uv` records the
-new tag as `_commit` in `.copier-answers.yml`.
+Afterwards, verify the release and tag target, then confirm a fresh render records the
+new tag as `_commit` in `.copier-answers.yml`:
+
+```shell
+gh release view "$NEW_TAG" --repo jlevy/simple-modern-uv \
+  --json tagName,targetCommitish,isDraft
+git fetch origin tag "$NEW_TAG"
+test "$(git rev-list -n 1 "$NEW_TAG")" = "$TEMPLATE_COMMIT"
+RELEASE_CHECK_DIR=$(mktemp -d)
+uvx --exclude-newer "14 days" copier@9.17.0 copy --defaults \
+  --vcs-ref "$NEW_TAG" gh:jlevy/simple-modern-uv "$RELEASE_CHECK_DIR"
+grep -q "^_commit: ${NEW_TAG}$" \
+  "$RELEASE_CHECK_DIR/.copier-answers.yml"
+```
 
 ## Step 8: Record the Release Tag Downstream
 
@@ -363,14 +446,46 @@ This should either be a no-op or only change `_commit`.
 
 ```shell
 cd ../simple-modern-uv-template
+git switch main
+git pull --ff-only origin main
+RECORD_BRANCH="record-${NEW_TAG}-template"
+git switch -c "$RECORD_BRANCH"
 uvx --exclude-newer "14 days" copier@9.17.0 update --defaults \
   --vcs-ref "$NEW_TAG"
 git diff -- .copier-answers.yml
 
 git add -A
-git commit -m "Record simple-modern-uv template ${NEW_TAG}."  # skip if no diff
-git push origin main
+git commit -m "Record simple-modern-uv template ${NEW_TAG}."
+git push -u origin "$RECORD_BRANCH"
+
+RECORD_PR=$(gh pr create \
+  --repo jlevy/simple-modern-uv-template \
+  --base main \
+  --head "$RECORD_BRANCH" \
+  --title "chore: record simple-modern-uv template ${NEW_TAG}" \
+  --body "Records the public ${NEW_TAG} template tag after release validation.")
+gh pr checks "$RECORD_PR" --watch
+gh pr merge "$RECORD_PR" --merge --delete-branch
+
+RECORD_COMMIT=$(gh pr view "$RECORD_PR" \
+  --repo jlevy/simple-modern-uv-template \
+  --json mergeCommit -q '.mergeCommit.oid')
+RECORD_RUN_ID=$(gh run list \
+  --repo jlevy/simple-modern-uv-template \
+  --workflow CI \
+  --branch main \
+  --event push \
+  --commit "$RECORD_COMMIT" \
+  --json databaseId \
+  -q '.[0].databaseId')
+test -n "$RECORD_RUN_ID"
+gh run watch --repo jlevy/simple-modern-uv-template \
+  "$RECORD_RUN_ID" --exit-status
 ```
+
+If the tagged update produces no diff, skip the commit and second downstream PR. If
+GitHub has not yet queued the final `main` run, wait for it to appear and repeat the
+`RECORD_RUN_ID` query.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.


### PR DESCRIPTION
## Summary

- advance the frozen uv pin to 0.12.0 and refresh eligible supporting tools and actions
- replace generated CI's `--frozen` syncs with `--locked` validation
- add a checked-in `uv.toml` selected explicitly by Make and GitHub Actions, keeping lockfiles independent of ambient user configuration
- keep Ruff 0.16 scoped to Python by excluding Markdown, which remains Flowmark's responsibility
- make agent-driven adoption first-class for new projects, selected features, full migrations, and future template updates
- define selective, core-toolchain, and full template-managed adoption without inventing Copier lineage for partial use
- apply tbd's Common Documentation Guidelines across the changed documentation, including a maintainer index, direct workflow links, calibrated claims, and clear current-versus-historical ownership
- document the uv 0.12 review, supply-chain evidence, deferrals, and template decisions
- align generated workflow guidance with the enforced uv 0.12 compatibility line

## Focus and Compatibility

This is a focused currency, hardening, agent-workflow, and documentation update. Existing generated projects keep Hatchling and uv-dynamic-versioning; no template question or application-facing behavior changes. The added rendered `uv.toml` makes this a v0.5.0 candidate under the repository's versioning policy.

The portable skill remains one coherent bundle with direct, one-level procedures. Generated README and AGENTS guidance make routine project work self-contained and route only toolchain or template maintenance back to the skill. The skill deliberately omits experimental `allowed-tools` frontmatter: that key is not cross-agent portable, and pre-approving a general package runner would grant more authority than the workflow needs.

Generated agent commands deliberately retain explicit `--exclude-newer "14 days"` guards so copied snippets remain safe. Their root-relative `UV_CONFIG_FILE=uv.toml` form matches the documented repository-root workflow and fails closed from the wrong directory.

The freeze is 2026-08-14T18:59:05Z with a 14-day cutoff. uv 0.12.0 is the newest eligible release; uv 0.12.1 through 0.12.4 and other too-recent releases remain deferred.

## Upgrading

Generated projects now require the reviewed uv 0.12 minor line (`>=0.12.0,<0.13`). Upgrade older installations before running project commands; uv older than 0.9.17 may fail while parsing `"14 days"` before it can show the required-version message. Later uv minor lines stay blocked until this template reviews them.

Ruff 0.16 includes Markdown in its default formatter inputs. Generated projects now set `[tool.ruff] extend-exclude = ["*.md"]` so Flowmark owns Markdown and Ruff owns Python. Projects that intentionally want Ruff to format Python fences can remove that exclusion. Template updates should also remove obsolete `UV_NO_CONFIG` workarounds after adopting `uv.toml` and explicit `UV_CONFIG_FILE` settings.

## Validation

- `make format-check` and `git diff --check`
- Common Doc audit of headings, audience/cadence boundaries, duplication, present-state language, claims, footers, spelling, relative links, and local anchors
- root and rendered workflow YAML parsing
- `skills-ref@0.1.5 validate skills/simple-modern-uv`
- default, no-publish/proprietary, and no-license Copier 9.17.0 renders
- current-worktree default/private documentation renders with rendered-link validation
- Python 3.12 install, codespell/Ruff/BasedPyright, pytest, and locked non-isolated build
- Ruff Markdown-discovery reproduction plus a rendered regression fixture that keeps an intentionally unformatted Python fence unchanged
- agent-ready Python 3.14 render: install, lint, test, and build
- project-scoped `skills@1.5.18` installation with byte-for-byte bundle comparison
- Copier update from v0.4.0 with no rejects and byte-for-byte convergence
- `uv sync --locked` stale-lock rejection
- lock portability under normal and empty user configuration
- `uv audit --locked`: no known vulnerabilities or adverse statuses in the resolved third-party graph
- official checksums and GitHub attestations for selected uv and Ruff Linux artifacts

## Deferred Follow-Ups

- preview uv commands (`audit`, `check`, and `format`) stay out of generated CI
- setup-uv v10 and uv 0.12.1+ have not cleared the cutoff
- get-tbd modernization remains tracked separately in `smu-i8xh`

Tracked by `smu-w9r5`, `smu-xn5s`, `smu-3403`, and review bead `smu-4t3e`.

## Release Process

- documents v0.5.0 as a five-stage release: candidate PR, exact source-main CI, downstream validation PR and main CI, GitHub Release, then downstream tag recording
- makes the GitHub Release the sole tag-creation step and verifies the tag resolves to the validated commit
- checks that the installed GitHub CLI supports commit-filtered workflow lookup before release work begins
- states that update-path CI guarantees the latest-release jump; older projects should validate one release hop at a time
- corrects the maintainer smoke-test recipe to create the Git commit required by dynamic versioning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect generated CI, lockfile validation, and uv version requirements across all new and updated projects; supply-chain and agent-workflow surface area is large but heavily gated by expanded template-repo CI.
> 
> **Overview**
> This PR advances the template to **uv 0.12.0** (with Copier 9.17.0, refreshed Actions, and bumped dev pins) and treats the change as a **v0.5.0**-style release because generated projects gain a checked-in **`uv.toml`** instead of `[tool.uv]` in `pyproject.toml`.
> 
> **Lockfile and CI hardening:** Generated workflows switch from `uv sync --frozen` to **`--locked`**, set **`UV_CONFIG_FILE: uv.toml`**, and pin the reviewed uv line (`>=0.12.0,<0.13`). The Makefile exports the same config so user-level uv settings do not leak into `uv.lock`. Publish jobs disable shared uv cache; Ruff **0.16+** is scoped with `extend-exclude = ["*.md"]` so Flowmark keeps Markdown; template CI adds a regression fixture for that split.
> 
> **Agent skill:** The portable skill is restructured into a router plus one-level references for **new project**, **selective adoption**, **full migration**, and **template update**, with explicit **selective / core / full template-managed** levels and no fake Copier lineage for partial use. README, generated `AGENTS.md`/`README`, and maintainer docs align with four workflows and a documented five-stage release process in `updating.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c18ad01b95f95d68cca0268b1d9bbda4fd106c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->