### PR TITLE
fix: validate rendered documentation formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           grep -q 'UV_CONFIG_FILE := .*uv.toml' Makefile
           grep -q '@AGENTS.md' CLAUDE.md
           test -f .copier-answers.yml
+          uvx flowmark-rs@0.3.2 --auto --check .
 
       - name: Init git and install (the documented setup sequence)
         # Mirrors the next-steps the template prints: commit first, then sync, so

--- a/docs/project/research/research-v0.5.0-supply-chain-manifest.md
+++ b/docs/project/research/research-v0.5.0-supply-chain-manifest.md
@@ -131,7 +131,8 @@ Local validation produced these outcomes:
 2. `uv audit --locked` reports no known vulnerabilities or adverse project statuses in
    the 24 third-party packages.
 3. Fresh default, no-publish/proprietary, and no-license renders have the expected file,
-   license, classifier, and workflow shapes.
+   license, classifier, and workflow shapes, and their rendered Markdown passes Flowmark
+   0.3.2.
 4. The Python 3.12 default render installs, passes codespell/Ruff/BasedPyright and
    pytest, and builds its sdist and wheel through the locked non-isolated Hatchling
    path. An intentionally unformatted Python fence under `tests/` verifies that Ruff

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -1,7 +1,8 @@
 # Project Instructions for AI Agents
 
-Instructions for AI coding agents working on {{ package_name }}. This file follows the
-[AGENTS.md](https://agents.md) convention.
+Instructions for AI coding agents working on {{ package_name }}.
+
+This file follows the [AGENTS.md](https://agents.md) convention.
 Claude Code reads `CLAUDE.md`, which imports this file through its `@AGENTS.md` line, so
 both instruction paths stay aligned.
 

--- a/template/docs/development.md.jinja
+++ b/template/docs/development.md.jinja
@@ -6,10 +6,11 @@ This project is set up to use [uv](https://docs.astral.sh/uv/) to manage Python 
 dependencies. First, be sure you
 [have uv installed](https://docs.astral.sh/uv/getting-started/installation/).
 
-Then
-[fork the {{package_github_org}}/{{package_name}} repo](https://github.com/{{package_github_org}}/{{package_name}}/fork)
-(having your own fork will make it easier to contribute) and
+[Fork the project][project-fork] (having your own fork will make it easier to
+contribute) and
 [clone it](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
+
+[project-fork]: https://github.com/{{package_github_org}}/{{package_name}}/fork
 
 ## Basic Developer Workflows
 


### PR DESCRIPTION
## Summary

- make rendered AGENTS and development guidance Flowmark-canonical after Jinja substitution
- require every template render variant to pass the pinned Flowmark 0.3.2 check
- record the rendered-document gate in the frozen v0.5.0 manifest

## Why

The v0.5.0 downstream release gate found two rendered line breaks that differed from Flowmark's canonical output even though the `.md.jinja` sources passed formatting. This closes that source-versus-render gap before tagging.

## Validation

- `make format-check` and `git diff --check`
- workflow YAML parsing
- default, no-publish/proprietary, and no-license Copier 9.17.0 renders
- pinned Flowmark 0.3.2 check over every rendered project
- default render: install, lint/Ruff/BasedPyright, pytest, locked non-isolated build, and uv 0.12.0 audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting and CI validation only; no runtime, auth, or dependency behavior changes.
> 
> **Overview**
> Closes a **source-vs-render gap** where `.md.jinja` passed Flowmark in the template repo but Copier output could still differ (e.g. line breaks in **AGENTS** and **development** docs).
> 
> **CI** now runs pinned **Flowmark 0.3.2** (`uvx flowmark-rs@0.3.2 --auto --check .`) on every render variant (default, no-publish/proprietary, no-license) during the render smoke test.
> 
> **Template sources** are adjusted so substituted Markdown is Flowmark-canonical: `AGENTS.md.jinja` splits the intro into separate paragraphs; `development.md.jinja` uses a reference-style fork link instead of an inline URL.
> 
> The **v0.5.0 supply-chain manifest** records that all three render shapes pass the Flowmark check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab3144efd3ec5856444b3ca13627d7f046352e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->